### PR TITLE
Removed redundant exit command

### DIFF
--- a/payloads/extensions/windows_hid_exfil.txt
+++ b/payloads/extensions/windows_hid_exfil.txt
@@ -51,7 +51,6 @@ EXTENSION WINDOWS_HID_EXFIL
             $o+="%{SCROLLLOCK}";
             Add-Type -Assembly System.Windows.Forms;
             [System.Windows.Forms.SendKeys]::SendWait("$o");
-            exit;
         END_STRING
         IF_DEFINED_TRUE #CLOSE_AFTER_EXFIL
             STRING exit;


### PR DESCRIPTION
Removed redundant exit command in payloads/extensions/windows_hid_exfil.txt , line 54