### PR TITLE
Add D-Hack prank payload

### DIFF
--- a/payloads/library/prank/D-Hack/README.md
+++ b/payloads/library/prank/D-Hack/README.md
@@ -1,0 +1,241 @@
+# D-Hack Prank
+#### by: Hackgotchi🪼
+
+>A retro movie-style computer being hacked prank for the Hak5 USB Rubber Ducky.
+
+This harmless Windows prank uses the USB Rubber Ducky's **HID** and **STORAGE** modes to launch a hidden PowerShell script from the Ducky's storage partition.
+
+ the script displays randomized fake security alerts, animated loading bars, warning messages, system sounds, colors, icons, and oversized emojis at different positions across the screen.
+
+The computer is **not actually hacked**. The payload does not collect credentials, steal information, download external files, or modify system settings. When the prank ends, all remaining popup jobs are stopped and a final message reveals that the user has been pranked.
+
+
+## Target
+
+- Windows 10
+- Windows 11
+
+## Required Files
+
+Place these files in the root of the Rubber Ducky storage partition:
+
+```text
+payload.txt
+run_hidden.vbs
+prank.ps1
+```
+
+Your Ducky storage should look like this:
+
+```text
+DUCKY/
+├── payload.txt
+├── prank.ps1
+└── run_hidden.vbs
+```
+
+The storage partition must be labeled:
+
+```text
+DUCKY
+```
+
+> [!IMPORTANT]
+> The PowerShell file must be named exactly `prank.ps1` and saved using **UTF-8-BOM** encoding so emojis and special characters display correctly.
+
+## How It Works
+
+1. The Rubber Ducky starts in HID and storage mode.
+2. It opens the Windows Run dialog.
+3. PowerShell searches for a mounted drive labeled `DUCKY`.
+4. The payload launches `run_hidden.vbs` from that drive.
+5. The VBScript starts `prank.ps1` with no visible PowerShell window.
+6. The fake hacking effects run for approximately 30 or to what ever you set it to seconds.
+7. All popup jobs are cleaned up and the prank is revealed.
+
+
+```
+### Main `prank.ps1` Settings
+
+The main prank settings are located near the beginning of `prank.ps1`:
+
+```powershell
+$duration = 30
+$interval = 2
+$popupsPerCycle = 6
+$maxActiveJobs = 12
+
+# Sound settings
+$enableSounds = $true
+$soundChancePercent = 100
+```
+
+## Customization
+
+You can customize the prank directly inside `prank.ps1`.
+
+### Duration and Popup Count
+
+```powershell
+$duration = 30
+$interval = 2
+$popupsPerCycle = 6
+$maxActiveJobs = 12
+```
+
+- `$duration` — total prank duration in seconds
+- `$interval` — delay between popup cycles
+- `$popupsPerCycle` — number of popups created during each cycle
+- `$maxActiveJobs` — maximum number of popup jobs allowed at once
+
+> [!WARNING]
+> Increasing the popup count or reducing the interval may use more system resources.
+
+### Fake Loading Messages
+
+```powershell
+$loadingPhrases = @(
+    "BYPASSING FIREWALL...",
+    "BREACH IN PROGRESS...",
+    "INSTALLING VIRUS...",
+    "DOWNLOADING DATA..."
+)
+```
+
+Add, remove, or replace any message inside the array.
+
+### Fake Alert Messages
+
+```powershell
+$alertPhrases = @(
+    "HACKED",
+    "VIRUS DETECTED",
+    "SYSTEM COMPROMISED",
+    "ALERT",
+    "SECURITY ALERT: DATA AT RISK",
+    "CRITICAL SECURITY BREACH",
+    "YOUR IP HAS BEEN EXPOSED",
+    "WARNING: UNAUTHORIZED ACCESS DETECTED",
+    "MALICIOUS ACTIVITY DETECTED"
+)
+```
+
+### Emojis
+
+```powershell
+$emojis = @(
+    "💀",
+    "🪼",
+    "🐱"
+)
+```
+
+Remember to keep `prank.ps1` saved as **UTF-8 with BOM** when using emojis.
+
+### Popup Colors
+
+```powershell
+$colors = @(
+    "GreenYellow",
+    "Black",
+    "HotPink"
+)
+```
+
+The values must be valid .NET `System.Drawing.Color` names.
+
+### Window Icons
+
+```powershell
+$icons = @(
+    "Information",
+    "Warning",
+    "Error"
+)
+```
+
+### System Sounds
+
+```powershell
+$enableSounds = $true
+$soundChancePercent = 100
+
+$sounds = @(
+    "Asterisk",
+    "Beep",
+    "Exclamation",
+    "Hand",
+    "Question"
+)
+```
+
+Set `$enableSounds` to `$false` to disable sounds.
+
+Use `$soundChancePercent` to control how often a popup plays a sound:
+
+```powershell
+$soundChancePercent = 50
+```
+
+### Progress-Bar Style
+
+```powershell
+$progressBar.Style = "Continuous"
+```
+
+Available styles include:
+
+```powershell
+$progressBar.Style = "Blocks"
+$progressBar.Style = "Continuous"
+$progressBar.Style = "Marquee"
+```
+
+- `Blocks` — segmented progress bar
+- `Continuous` — smooth progress bar
+- `Marquee` — moving animation without a fixed percentage
+
+## Features
+
+- Retro movie-style fake hacking experience
+- Runs PowerShell with no visible console window
+- Automatically detects the Ducky storage drive
+- Works regardless of the assigned drive letter
+- Random fake security-alert windows
+- Animated fake hacking loading bars
+- Random colors, icons, messages, emojis, and sounds
+- Customizable duration and popup frequency
+- Limits the number of simultaneous popup jobs
+- Automatically cleans up PowerShell jobs
+- Ends with a clear prank reveal
+
+
+## Troubleshooting
+
+### Nothing Happens
+
+Confirm that:
+
+- The storage partition is labeled `DUCKY`
+- All three files are in the root of the storage partition
+- The filenames exactly match the required names
+- `prank.ps1` must be is saved as **UTF-8 with BOM Encoding**
+- Windows PowerShell and Windows Script Host are available
+- The Ducky payload compiled successfully
+
+### Emojis Display Incorrectly
+
+Open `prank.ps1` in a text editor and save as:
+
+```text
+UTF-8-BOM
+```
+
+In notepad/text editor, click file > save as > at the bottom change UTF-8 to **UTF-8 with BOM**
+
+
+## Disclaimer
+
+This payload is intended only as a harmless fake hacking prank on systems you own or have explicit permission to test.
+
+Do not use it on another person's device without their knowledge and permission. The author is not responsible for misuse, disruption, data loss, or damage caused by unauthorized use.

--- a/payloads/library/prank/D-Hack/payload.txt
+++ b/payloads/library/prank/D-Hack/payload.txt
@@ -1,0 +1,12 @@
+REM Title:  hackagocthi
+REM Author  D-Hack
+REM Target  Windows 10/11
+REM Description This Windows prank payload silently launches a PowerShell script from the Rubber Ducky and displays fake security alerts in a retro movie-style “computer being hacked” theme. It shows randomized popups, loading bars, alert sounds, colors, and emojis before revealing that it was only a prank.
+
+
+ATTACKMODE HID STORAGE
+DELAY 1500
+GUI r
+DELAY 600
+STRING powershell.exe -NoProfile -WindowStyle Hidden -Command "$d=(Get-CimInstance Win32_LogicalDisk|Where-Object{$_.VolumeName -eq 'DUCKY'}|Select-Object -First 1 -ExpandProperty DeviceID);if($d){Start-Process wscript.exe -ArgumentList ($d+'\run_hidden.vbs')}"
+ENTER

--- a/payloads/library/prank/D-Hack/prank.ps1
+++ b/payloads/library/prank/D-Hack/prank.ps1
@@ -1,0 +1,782 @@
+﻿$duration = 30  #Prank duration
+$interval = 2   #Delay between popup cycles
+$popupsPerCycle = 6  #Delay between popup cycles
+$maxActiveJobs = 12  #Maximum number of active popups
+
+# Sound settings
+$enableSounds = $true  #System sounds
+$soundChancePercent = 100  #Sound frequency
+
+$endTime = (Get-Date).AddSeconds($duration)
+$counter = 0
+$jobPrefix = "PrankPopup-"
+
+#Loading-bar messages
+$loadingPhrases = @(
+    "BYPASSING FIREWALL...",
+    "BREACH IN PROGRESS...",
+    "INSTALLING VIRUS...",
+    "DOWNLOADING DATA..."
+)
+
+#Regular pop-ups phrases
+$alertPhrases = @(
+    "HACKED",
+    "VIRUS DETECTED",
+    "SYSTEM COMPROMISED",
+    "ALERT",
+    "SECURITY ALERT: DATA AT RISK",
+    "CRITICAL SECURITY BREACH",
+    "YOUR IP HAS BEEN EXPOSED",
+    "WARNING: UNAUTHORIZED ACCESS DETECTED",
+    "MALICIOUS ACTIVITY DETECTED"
+)
+
+#Emojis
+$emojis = @(
+    "💀",
+    "🪼",
+    "🐱"
+)
+
+#Popup colors
+$colors = @(
+    "GreenYellow",
+    "Black",
+    "HotPink"
+)
+
+$icons = @(
+    "Information",
+    "Warning",
+    "Error"
+)
+
+# Built-in Windows sounds
+$sounds = @(
+    "Asterisk",
+    "Beep",
+    "Exclamation",
+    "Hand",
+    "Question"
+)
+
+# Get jobs created by this script
+function Get-PrankJobs {
+    @(
+        Get-Job -ErrorAction SilentlyContinue |
+            Where-Object {
+                $_.Name -like "$jobPrefix*"
+            }
+    )
+}
+
+function Get-RunningPrankJobs {
+    @(
+        Get-PrankJobs |
+            Where-Object {
+                $_.State -eq "Running"
+            }
+    )
+}
+
+function Get-RunningPrankJobCount {
+    @(Get-RunningPrankJobs).Count
+}
+
+function Remove-FinishedPrankJobs {
+    Get-PrankJobs |
+        Where-Object {
+            $_.State -in @(
+                "Completed",
+                "Failed",
+                "Stopped"
+            )
+        } |
+        Remove-Job -Force -ErrorAction SilentlyContinue
+}
+
+# Removes jobs left from an earlier run
+Get-RunningPrankJobs |
+    Stop-Job -ErrorAction SilentlyContinue
+
+Get-PrankJobs |
+    Remove-Job -Force -ErrorAction SilentlyContinue
+
+# Loading-bar popup
+$loadingPopupScript = {
+    param(
+        $Title,
+        $Message,
+        $DurationSeconds,
+        $BackColor,
+        $Width,
+        $Height,
+        $IconName,
+        $SoundName
+    )
+
+    Add-Type -AssemblyName System.Windows.Forms
+    Add-Type -AssemblyName System.Drawing
+
+    $form = New-Object System.Windows.Forms.Form
+    $form.Text = $Title
+    $form.ClientSize = New-Object System.Drawing.Size(
+        $Width,
+        $Height
+    )
+    $form.StartPosition = "Manual"
+    $form.BackColor = [System.Drawing.Color]::$BackColor
+    $form.TopMost = $true
+    $form.ShowInTaskbar = $false
+    $form.FormBorderStyle = "FixedDialog"
+    $form.MaximizeBox = $false
+    $form.MinimizeBox = $false
+
+    $form.Icon = switch ($IconName) {
+        "Error" {
+            [System.Drawing.SystemIcons]::Error
+        }
+
+        "Warning" {
+            [System.Drawing.SystemIcons]::Warning
+        }
+
+        default {
+            [System.Drawing.SystemIcons]::Information
+        }
+    }
+
+    $screen = [System.Windows.Forms.Screen]::PrimaryScreen.WorkingArea
+
+    $maximumX = [Math]::Max(
+        $screen.Right - $form.Width,
+        $screen.Left + 1
+    )
+
+    $maximumY = [Math]::Max(
+        $screen.Bottom - $form.Height,
+        $screen.Top + 1
+    )
+
+    $randomX = Get-Random `
+        -Minimum $screen.Left `
+        -Maximum $maximumX
+
+    $randomY = Get-Random `
+        -Minimum $screen.Top `
+        -Maximum $maximumY
+
+    $form.Location = New-Object System.Drawing.Point(
+        $randomX,
+        $randomY
+    )
+
+    $innerWidth = $Width - 20
+
+    $textColor = if (
+        $BackColor -in @(
+            "GreenYellow",
+            "HotPink"
+        )
+    ) {
+        [System.Drawing.Color]::Black
+    }
+    else {
+        [System.Drawing.Color]::White
+    }
+
+    $label = New-Object System.Windows.Forms.Label
+    $label.Text = $Message
+    $label.ForeColor = $textColor
+    $label.BackColor = [System.Drawing.Color]::Transparent
+    $label.Font = New-Object System.Drawing.Font(
+        "Segoe UI",
+        12,
+        [System.Drawing.FontStyle]::Bold
+    )
+    $label.AutoSize = $false
+    $label.Size = New-Object System.Drawing.Size(
+        $innerWidth,
+        35
+    )
+    $label.Location = New-Object System.Drawing.Point(10, 15)
+    $label.TextAlign = "MiddleCenter"
+
+    $form.Controls.Add($label)
+
+    $progressBar = New-Object System.Windows.Forms.ProgressBar
+    $progressBar.Location = New-Object System.Drawing.Point(10, 60)
+    $progressBar.Size = New-Object System.Drawing.Size(
+        $innerWidth,
+        25
+    )
+    $progressBar.Minimum = 0
+    $progressBar.Maximum = 100
+    $progressBar.Value = 0
+    $progressBar.Style = "Blocks"
+
+    $form.Controls.Add($progressBar)
+
+    try {
+        $form.Show()
+        $form.Activate()
+
+        try {
+            switch ($SoundName) {
+                "Asterisk" {
+                    [System.Media.SystemSounds]::Asterisk.Play()
+                }
+
+                "Beep" {
+                    [System.Media.SystemSounds]::Beep.Play()
+                }
+
+                "Exclamation" {
+                    [System.Media.SystemSounds]::Exclamation.Play()
+                }
+
+                "Hand" {
+                    [System.Media.SystemSounds]::Hand.Play()
+                }
+
+                "Question" {
+                    [System.Media.SystemSounds]::Question.Play()
+                }
+            }
+        }
+        catch {
+            # Ignore sound errors
+        }
+
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
+        $durationMilliseconds = [Math]::Max(
+            $DurationSeconds * 1000,
+            1
+        )
+
+        while (
+            $stopwatch.ElapsedMilliseconds -lt $durationMilliseconds -and
+            -not $form.IsDisposed -and
+            $form.Visible
+        ) {
+            $percentage = [int](
+                (
+                    $stopwatch.ElapsedMilliseconds /
+                    $durationMilliseconds
+                ) * 100
+            )
+
+            $progressBar.Value = [Math]::Min(
+                $percentage,
+                100
+            )
+
+            [System.Windows.Forms.Application]::DoEvents()
+            Start-Sleep -Milliseconds 20
+        }
+
+        if (
+            -not $form.IsDisposed -and
+            -not $progressBar.IsDisposed -and
+            $form.Visible
+        ) {
+            $progressBar.Value = 100
+            [System.Windows.Forms.Application]::DoEvents()
+            Start-Sleep -Milliseconds 100
+        }
+    }
+    catch {
+        # Close quietly if interrupted
+    }
+    finally {
+        if (-not $form.IsDisposed) {
+            $form.Close()
+        }
+
+        if (-not $progressBar.IsDisposed) {
+            $progressBar.Dispose()
+        }
+
+        if (-not $label.IsDisposed) {
+            $label.Dispose()
+        }
+
+        if (-not $form.IsDisposed) {
+            $form.Dispose()
+        }
+    }
+}
+
+# Regular popup
+$colorPopupScript = {
+    param(
+        $Title,
+        $Message,
+        $BackColor,
+        $Width,
+        $Height,
+        $IconName,
+        $SoundName
+    )
+
+    Add-Type -AssemblyName System.Windows.Forms
+    Add-Type -AssemblyName System.Drawing
+
+    $form = New-Object System.Windows.Forms.Form
+    $form.Text = $Title
+    $form.ClientSize = New-Object System.Drawing.Size(
+        $Width,
+        $Height
+    )
+    $form.StartPosition = "Manual"
+    $form.BackColor = [System.Drawing.Color]::$BackColor
+    $form.TopMost = $true
+    $form.ShowInTaskbar = $false
+    $form.FormBorderStyle = "FixedDialog"
+    $form.MaximizeBox = $false
+    $form.MinimizeBox = $false
+
+    $form.Icon = switch ($IconName) {
+        "Error" {
+            [System.Drawing.SystemIcons]::Error
+        }
+
+        "Warning" {
+            [System.Drawing.SystemIcons]::Warning
+        }
+
+        default {
+            [System.Drawing.SystemIcons]::Information
+        }
+    }
+
+    $screen = [System.Windows.Forms.Screen]::PrimaryScreen.WorkingArea
+
+    $maximumX = [Math]::Max(
+        $screen.Right - $form.Width,
+        $screen.Left + 1
+    )
+
+    $maximumY = [Math]::Max(
+        $screen.Bottom - $form.Height,
+        $screen.Top + 1
+    )
+
+    $randomX = Get-Random `
+        -Minimum $screen.Left `
+        -Maximum $maximumX
+
+    $randomY = Get-Random `
+        -Minimum $screen.Top `
+        -Maximum $maximumY
+
+    $form.Location = New-Object System.Drawing.Point(
+        $randomX,
+        $randomY
+    )
+
+    $innerWidth = $Width - 20
+
+    $labelHeight = [Math]::Max(
+        $Height - 60,
+        40
+    )
+
+    $textColor = if (
+        $BackColor -in @(
+            "GreenYellow",
+            "HotPink"
+        )
+    ) {
+        [System.Drawing.Color]::Black
+    }
+    else {
+        [System.Drawing.Color]::White
+    }
+
+    $label = New-Object System.Windows.Forms.Label
+    $label.Text = $Message
+    $label.ForeColor = $textColor
+    $label.BackColor = [System.Drawing.Color]::Transparent
+    $label.Font = New-Object System.Drawing.Font(
+        "Segoe UI",
+        10,
+        [System.Drawing.FontStyle]::Bold
+    )
+    $label.AutoSize = $false
+    $label.Size = New-Object System.Drawing.Size(
+        $innerWidth,
+        $labelHeight
+    )
+    $label.Location = New-Object System.Drawing.Point(10, 5)
+    $label.TextAlign = "MiddleCenter"
+
+    $form.Controls.Add($label)
+
+    $button = New-Object System.Windows.Forms.Button
+    $button.Text = "LOL"
+    $button.Size = New-Object System.Drawing.Size(75, 25)
+
+    $buttonX = [int](($Width - $button.Width) / 2)
+    $buttonY = $Height - $button.Height - 10
+
+    $button.Location = New-Object System.Drawing.Point(
+        $buttonX,
+        $buttonY
+    )
+
+    $button.Add_Click({
+        $form.Close()
+    })
+
+    $form.Controls.Add($button)
+
+    try {
+        $form.Show()
+        $form.Activate()
+
+        try {
+            switch ($SoundName) {
+                "Asterisk" {
+                    [System.Media.SystemSounds]::Asterisk.Play()
+                }
+
+                "Beep" {
+                    [System.Media.SystemSounds]::Beep.Play()
+                }
+
+                "Exclamation" {
+                    [System.Media.SystemSounds]::Exclamation.Play()
+                }
+
+                "Hand" {
+                    [System.Media.SystemSounds]::Hand.Play()
+                }
+
+                "Question" {
+                    [System.Media.SystemSounds]::Question.Play()
+                }
+            }
+        }
+        catch {
+            # Ignore sound errors
+        }
+
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
+        while (
+            $stopwatch.ElapsedMilliseconds -lt 3000 -and
+            -not $form.IsDisposed -and
+            $form.Visible
+        ) {
+            [System.Windows.Forms.Application]::DoEvents()
+            Start-Sleep -Milliseconds 20
+        }
+    }
+    catch {
+        # Close quietly if interrupted
+    }
+    finally {
+        if (-not $form.IsDisposed) {
+            $form.Close()
+        }
+
+        if (-not $button.IsDisposed) {
+            $button.Dispose()
+        }
+
+        if (-not $label.IsDisposed) {
+            $label.Dispose()
+        }
+
+        if (-not $form.IsDisposed) {
+            $form.Dispose()
+        }
+    }
+}
+
+#emoji popup
+$emojiPopupScript = {
+    param(
+        $Emoji,
+        $SoundName
+    )
+
+    Add-Type -AssemblyName System.Windows.Forms
+    Add-Type -AssemblyName System.Drawing
+
+    $formSize = 400
+    $fontSize = 160
+
+    $form = New-Object System.Windows.Forms.Form
+    $form.ClientSize = New-Object System.Drawing.Size(
+        $formSize,
+        $formSize
+    )
+    $form.StartPosition = "Manual"
+    $form.FormBorderStyle = "None"
+    $form.ShowInTaskbar = $false
+    $form.BackColor = [System.Drawing.Color]::Magenta
+    $form.TransparencyKey = [System.Drawing.Color]::Magenta
+    $form.TopMost = $true
+
+    $screen = [System.Windows.Forms.Screen]::PrimaryScreen.WorkingArea
+
+    $maximumX = [Math]::Max(
+        $screen.Right - $formSize,
+        $screen.Left + 1
+    )
+
+    $maximumY = [Math]::Max(
+        $screen.Bottom - $formSize,
+        $screen.Top + 1
+    )
+
+    $randomX = Get-Random `
+        -Minimum $screen.Left `
+        -Maximum $maximumX
+
+    $randomY = Get-Random `
+        -Minimum $screen.Top `
+        -Maximum $maximumY
+
+    $form.Location = New-Object System.Drawing.Point(
+        $randomX,
+        $randomY
+    )
+
+    $label = New-Object System.Windows.Forms.Label
+    $label.Text = $Emoji
+    $label.Font = New-Object System.Drawing.Font(
+        "Segoe UI Emoji",
+        $fontSize
+    )
+    $label.AutoSize = $false
+    $label.Size = New-Object System.Drawing.Size(
+        $formSize,
+        $formSize
+    )
+    $label.Location = New-Object System.Drawing.Point(0, 0)
+    $label.TextAlign = "MiddleCenter"
+    $label.BackColor = [System.Drawing.Color]::Transparent
+
+    $form.Controls.Add($label)
+
+    try {
+        $form.Show()
+        $form.Activate()
+
+        try {
+            switch ($SoundName) {
+                "Asterisk" {
+                    [System.Media.SystemSounds]::Asterisk.Play()
+                }
+
+                "Beep" {
+                    [System.Media.SystemSounds]::Beep.Play()
+                }
+
+                "Exclamation" {
+                    [System.Media.SystemSounds]::Exclamation.Play()
+                }
+
+                "Hand" {
+                    [System.Media.SystemSounds]::Hand.Play()
+                }
+
+                "Question" {
+                    [System.Media.SystemSounds]::Question.Play()
+                }
+            }
+        }
+        catch {
+            # Ignore sound errors
+        }
+
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
+        while (
+            $stopwatch.ElapsedMilliseconds -lt 2000 -and
+            -not $form.IsDisposed -and
+            $form.Visible
+        ) {
+            [System.Windows.Forms.Application]::DoEvents()
+            Start-Sleep -Milliseconds 20
+        }
+    }
+    catch {
+        # Close quietly if interrupted
+    }
+    finally {
+        if (-not $form.IsDisposed) {
+            $form.Close()
+        }
+
+        if (-not $label.IsDisposed) {
+            $label.Dispose()
+        }
+
+        if (-not $form.IsDisposed) {
+            $form.Dispose()
+        }
+    }
+}
+
+# Main loop
+while ((Get-Date) -lt $endTime) {
+    for ($i = 1; $i -le $popupsPerCycle; $i++) {
+
+        while (
+            (Get-RunningPrankJobCount) -ge $maxActiveJobs
+        ) {
+            Start-Sleep -Milliseconds 200
+            Remove-FinishedPrankJobs
+        }
+
+        $counter++
+
+        $jobName = "$jobPrefix$counter"
+        $randomColor = Get-Random -InputObject $colors
+        $randomIcon = Get-Random -InputObject $icons
+
+        $randomWidth = Get-Random `
+            -Minimum 240 `
+            -Maximum 451
+
+        $randomHeight = Get-Random `
+            -Minimum 120 `
+            -Maximum 251
+
+        # Decide whether this popup should make a sound
+        $randomSound = "None"
+
+        if (
+            $enableSounds -and
+            (Get-Random -Minimum 1 -Maximum 101) -le $soundChancePercent
+        ) {
+            $randomSound = Get-Random -InputObject $sounds
+        }
+
+        $popupType = Get-Random -InputObject @(
+            "Alert",
+            "Loading",
+            "Emoji"
+        )
+
+        switch ($popupType) {
+            "Alert" {
+                $randomPhrase = Get-Random -InputObject $alertPhrases
+
+                Start-Job `
+                    -Name $jobName `
+                    -ScriptBlock $colorPopupScript `
+                    -ArgumentList @(
+                        "Security Alert",
+                        $randomPhrase,
+                        $randomColor,
+                        $randomWidth,
+                        $randomHeight,
+                        $randomIcon,
+                        $randomSound
+                    ) |
+                    Out-Null
+            }
+
+            "Loading" {
+                $loadingHeight = [Math]::Max(
+                    $randomHeight,
+                    120
+                )
+
+                $randomPhrase = Get-Random -InputObject $loadingPhrases
+
+                Start-Job `
+                    -Name $jobName `
+                    -ScriptBlock $loadingPopupScript `
+                    -ArgumentList @(
+                        "Loading",
+                        $randomPhrase,
+                        5,
+                        $randomColor,
+                        $randomWidth,
+                        $loadingHeight,
+                        $randomIcon,
+                        $randomSound
+                    ) |
+                    Out-Null
+            }
+
+            "Emoji" {
+                $randomEmoji = Get-Random -InputObject $emojis
+
+                Start-Job `
+                    -Name $jobName `
+                    -ScriptBlock $emojiPopupScript `
+                    -ArgumentList @(
+                        $randomEmoji,
+                        $randomSound
+                    ) |
+                    Out-Null
+            }
+        }
+    }
+
+    Start-Sleep -Seconds $interval
+    Remove-FinishedPrankJobs
+}
+
+# Wait for popup to finish normally
+$waitUntil = (Get-Date).AddSeconds(12)
+
+while (
+    (Get-RunningPrankJobCount) -gt 0 -and
+    (Get-Date) -lt $waitUntil
+) {
+    Start-Sleep -Milliseconds 300
+    Remove-FinishedPrankJobs
+}
+
+# Stop remaining popup jobs
+Get-RunningPrankJobs |
+    Stop-Job -ErrorAction SilentlyContinue
+
+# Remove all jobs created by this script
+Get-PrankJobs |
+    Remove-Job -Force -ErrorAction SilentlyContinue
+
+# Final prank reveal
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+$owner = New-Object System.Windows.Forms.Form
+$owner.ClientSize = New-Object System.Drawing.Size(1, 1)
+$owner.StartPosition = "CenterScreen"
+$owner.FormBorderStyle = "None"
+$owner.ShowInTaskbar = $false
+$owner.TopMost = $true
+$owner.Opacity = 0
+
+$owner.Show()
+$owner.Activate()
+
+[System.Windows.Forms.Application]::DoEvents()
+
+try {
+    [System.Media.SystemSounds]::Exclamation.Play()
+}
+catch {
+    # Ignore sound errors
+}
+
+[System.Windows.Forms.MessageBox]::Show(
+    $owner,
+    "You have been pranked!",
+    "Prank Complete",
+    [System.Windows.Forms.MessageBoxButtons]::OK,
+    [System.Windows.Forms.MessageBoxIcon]::Information
+) | Out-Null
+
+$owner.Close()
+$owner.Dispose()

--- a/payloads/library/prank/D-Hack/run_hidden.vbs
+++ b/payloads/library/prank/D-Hack/run_hidden.vbs
@@ -1,0 +1,6 @@
+Set shell = CreateObject("WScript.Shell")
+
+cmd = "powershell.exe -NoProfile -STA -ExecutionPolicy Bypass -WindowStyle Hidden -Command " & _
+      """$d = (Get-CimInstance Win32_LogicalDisk | Where-Object { $_.VolumeName -eq 'DUCKY' } | Select-Object -First 1 -ExpandProperty DeviceID); if ($d) { & (Join-Path $d 'prank.ps1') }"""
+
+shell.Run cmd, 0, False


### PR DESCRIPTION
Adds the D-Hack payload to the prank library.

The payload creates a harmless fake hacking experience on Windows for approximately 30 seconds using randomized security alerts, loading animations, sounds, color popups, icons, and emojis.

It does not collect data, download files, modify system settings, or cause permanent changes.

Included files:
- payload.txt
- prank.ps1
- run_hidden.vbs
- README.md